### PR TITLE
Refactor OpenAI vocabulary handling:

### DIFF
--- a/crates/wordchipper/src/vocab/public/openai/mod.rs
+++ b/crates/wordchipper/src/vocab/public/openai/mod.rs
@@ -10,3 +10,42 @@ pub use patterns::*;
 pub use resources::*;
 #[doc(inline)]
 pub use specials::*;
+
+#[cfg(feature = "download")]
+mod pretrained {
+    use crate::regex::RegexWrapperPattern;
+    use crate::segmentation::SegmentationConfig;
+    use crate::types::TokenType;
+    use crate::vocab::UnifiedTokenVocab;
+    use crate::vocab::io::load_tiktoken_vocab_path;
+    use crate::vocab::public::openai::{
+        OA_GPT2_R50K_BASE_TIKTOKEN, OA_GPT2_R50K_WORD_PATTERN, oa_gpt2_r50k_specials,
+    };
+    use wordchipper_disk_cache::WordchipperDiskCache;
+
+    /// Load gpt2-r50k pretrained vocabulary.
+    pub fn experimental_load_gpt2_r50k<T: TokenType>(
+        disk_cache: &mut WordchipperDiskCache
+    ) -> anyhow::Result<UnifiedTokenVocab<T>> {
+        let span_map = load_tiktoken_vocab_path(disk_cache.load_cached_path(
+            &["openai", "gpt2-r50k"],
+            OA_GPT2_R50K_BASE_TIKTOKEN.urls,
+            true,
+        )?)?;
+
+        let pattern: RegexWrapperPattern = OA_GPT2_R50K_WORD_PATTERN.into();
+
+        let segmentation = SegmentationConfig::<T>::from_pattern(pattern.clone())
+            .with_special_words(
+                oa_gpt2_r50k_specials()
+                    .iter()
+                    .map(|(s, t)| (s, T::from_usize(*t).unwrap())),
+            );
+
+        let vocab = UnifiedTokenVocab::from_span_vocab(segmentation, span_map.into());
+        Ok(vocab)
+    }
+}
+#[cfg(feature = "download")]
+#[doc(inline)]
+pub use pretrained::*;

--- a/crates/wordchipper/src/vocab/public/openai/resources.rs
+++ b/crates/wordchipper/src/vocab/public/openai/resources.rs
@@ -4,36 +4,36 @@ use crate::vocab::utility::resource_tools::ConstUrlResource;
 
 /// The GPT-2 Data Gym "vocab.bpe" vocabulary resource.
 pub const OA_GPT2_DATAGYM_VOCAB_BPE: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe",
+    urls: &["https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe"],
     hash: Some("1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5"),
 };
 
 /// The GPT-2 Data Gym "encoder.json" vocabulary resource.
 pub const OA_GPT2_DATAGYM_ENCODER_JSON: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json",
+    urls: &["https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json"],
     hash: Some("196139668be63f3b5d6574427317ae82f612a97c5d1cdaf36ed2256dbf636783"),
 };
 
 /// The "`r50k_base.tiktoken`" vocabulary resource.
 pub const OA_GPT2_R50K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
+    urls: &["https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken"],
     hash: Some("306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930"),
 };
 
 /// The "`p50k_base.tiktoken`" vocabulary resource.
 pub const OA_GPT2_P50K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+    urls: &["https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken"],
     hash: Some("94b5ca7dff4d00767bc256fdd1b27e5b17361d7b8a5f968547f9f23eb70d2069"),
 };
 
 /// The "`cl100k_base.tiktoken`" vocabulary resource.
 pub const OA_GPT3_CL100K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
+    urls: &["https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"],
     hash: Some("223921b76ee99bde995b7ff738513eef100fb51d18c93597a113bcffe865b2a7"),
 };
 
 /// The "`o200k_base.tiktoken`" vocabulary resource.
 pub const OA_GPT5_O200K_BASE_TIKTOKEN: ConstUrlResource = ConstUrlResource {
-    url: "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+    urls: &["https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken"],
     hash: Some("446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d"),
 };

--- a/crates/wordchipper/src/vocab/utility/resource_tools.rs
+++ b/crates/wordchipper/src/vocab/utility/resource_tools.rs
@@ -3,7 +3,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ConstUrlResource {
     /// The URL associated with this resource.
-    pub url: &'static str,
+    pub urls: &'static [&'static str],
 
     /// The hash associated with this resource, if available.
     pub hash: Option<&'static str>,
@@ -12,14 +12,14 @@ pub struct ConstUrlResource {
 impl ConstUrlResource {
     /// Create a new [`ConstUrlResource`].
     pub const fn new(
-        url: &'static str,
+        urls: &'static [&'static str],
         hash: Option<&'static str>,
     ) -> Self {
-        Self { url, hash }
+        Self { urls, hash }
     }
 
     /// Create a new [`ConstUrlResource`] with no hash.
-    pub const fn no_hash(url: &'static str) -> Self {
-        Self::new(url, None)
+    pub const fn no_hash(urls: &'static [&'static str]) -> Self {
+        Self::new(urls, None)
     }
 }


### PR DESCRIPTION
- Add `experimental_load_gpt2_r50k` function for streamlined GPT-2 vocabulary loading.
- Update `ConstUrlResource` to support multiple URLs.
- Replace redundant token-cli initialization logic with reusable `experimental_load_gpt2_r50k`.
- Transition `url` fields to `urls` throughout OpenAI vocabulary resources.