### PR TITLE
Document `download` feature across README and library. Update default…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ See:
 #### feature: ``default``
 
 * ``client``
+* ``download``
 
-The default feature enables ``client``, with no training code.
+The default feature does not enable ``training``.
 
 #### feature: ``client``
 
@@ -56,6 +57,13 @@ The default feature enables ``client``, with no training code.
 
 The default client is focused on loading vocabularies and running
 high performance encoders / decoders.
+
+#### feature: ``download``
+
+* ``wordchipper-disk-cache``
+* ``std``
+
+The download feature enables downloading vocabularies from the internet.
 
 #### feature: ``training``
 

--- a/crates/wordchipper/README.md
+++ b/crates/wordchipper/README.md
@@ -17,8 +17,9 @@ The current status is productionization towards an alpha release.
 #### feature: ``default``
 
 * ``client``
+* ``download``
 
-The default feature enables ``client``, with no training code.
+The default feature does not enable ``training``.
 
 #### feature: ``client``
 
@@ -28,6 +29,13 @@ The default feature enables ``client``, with no training code.
 
 The default client is focused on loading vocabularies and running
 high performance encoders / decoders.
+
+#### feature: ``download``
+
+* ``wordchipper-disk-cache``
+* ``std``
+
+The download feature enables downloading vocabularies from the internet.
 
 #### feature: ``training``
 

--- a/crates/wordchipper/src/lib.rs
+++ b/crates/wordchipper/src/lib.rs
@@ -18,8 +18,10 @@
 //! #### feature: ``default``
 //!
 //! * ``client``
+//! * ``download``
 //!
-//! The default feature enables "client", with no training code.
+//!
+//! The default feature does not enable "training".
 //!
 //! #### feature: ``client``
 //!
@@ -29,6 +31,13 @@
 //!
 //! The default client is focused on loading vocabularies and running
 //! high performance encoders / decoders.
+//!
+//! #### feature: ``download``
+//!
+//! * ``wordchipper-disk-cache``
+//! * ``std``
+//!
+//! The download feature enables downloading vocabularies from the internet.
 //!
 //! #### feature: ``training``
 //!


### PR DESCRIPTION
… feature description to include `download` and clarify it does not enable `training`.