### PR TITLE
Regex unittests.

### DIFF
--- a/crates/wordchipper/src/regex/mod.rs
+++ b/crates/wordchipper/src/regex/mod.rs
@@ -80,3 +80,28 @@ pub fn regex_pool_supplier(regex: RegexWrapperHandle) -> RegexSupplierHandle {
     #[cfg(not(feature = "std"))]
     regex
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alloc::string::ToString;
+
+    #[test]
+    fn test_default_regex_supplier() {
+        let regex = RegexWrapperPattern::Basic("hello world".to_string())
+            .compile()
+            .unwrap();
+        let supplier = default_regex_supplier(regex.into());
+        assert_eq!(supplier.get_regex().as_str(), "hello world");
+    }
+
+    #[test]
+    fn test_regex_pool_supplier() {
+        let regex = RegexWrapperPattern::Basic("hello world".to_string())
+            .compile()
+            .unwrap();
+        let supplier = regex_pool_supplier(regex.into());
+
+        assert_eq!(supplier.get_regex().as_str(), "hello world");
+    }
+}

--- a/crates/wordchipper/src/regex/regex_pool.rs
+++ b/crates/wordchipper/src/regex/regex_pool.rs
@@ -1,9 +1,11 @@
 //! # Thread Regex Pool
 #![allow(unused)]
+
 use crate::alloc::sync::Arc;
 use crate::regex::regex_supplier::RegexSupplier;
 use crate::regex::regex_wrapper::RegexWrapper;
 use crate::types::CommonHashMap;
+use core::fmt::Debug;
 use core::num::NonZero;
 use parking_lot::RwLock;
 use std::thread::ThreadId;
@@ -22,6 +24,17 @@ pub struct RegexWrapperPool {
 
     max_pool: u64,
     pool: Arc<RwLock<CommonHashMap<u64, Arc<RegexWrapper>>>>,
+}
+
+impl Debug for RegexWrapperPool {
+    fn fmt(
+        &self,
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
+        f.debug_struct("RegexPool")
+            .field("regex", &self.regex)
+            .finish()
+    }
 }
 
 impl From<Arc<RegexWrapper>> for RegexWrapperPool {

--- a/crates/wordchipper/src/regex/regex_supplier.rs
+++ b/crates/wordchipper/src/regex/regex_supplier.rs
@@ -4,13 +4,13 @@ use crate::alloc::fmt::Debug;
 use crate::alloc::string::String;
 use crate::alloc::string::ToString;
 use crate::alloc::sync::Arc;
-use crate::regex::RegexWrapper;
+use crate::regex::{RegexWrapper, RegexWrapperHandle};
 
 /// Common Regex Supplier Handle Type
 pub type RegexSupplierHandle = Arc<dyn RegexSupplier>;
 
 /// Regex Supplier Trait
-pub trait RegexSupplier: Sync + Send {
+pub trait RegexSupplier: Sync + Send + Debug {
     /// Get the regex.
     ///
     /// ## Returns
@@ -26,23 +26,36 @@ pub trait RegexSupplier: Sync + Send {
     }
 }
 
-impl Debug for dyn RegexSupplier {
-    fn fmt(
-        &self,
-        f: &mut alloc::fmt::Formatter<'_>,
-    ) -> alloc::fmt::Result {
-        write!(f, "RegexSupplier({})", self.get_pattern())
-    }
-}
-
 impl RegexSupplier for RegexWrapper {
     fn get_regex(&self) -> Arc<RegexWrapper> {
         Arc::new(self.clone())
     }
 }
 
-impl RegexSupplier for Arc<RegexWrapper> {
+impl RegexSupplier for RegexWrapperHandle {
     fn get_regex(&self) -> Arc<RegexWrapper> {
         self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regex::{RegexWrapperHandle, RegexWrapperPattern};
+
+    #[test]
+    fn test_regex_supplier() {
+        let pattern: RegexWrapperPattern = r"foo".into();
+        let wrapper: RegexWrapper = pattern.compile().unwrap();
+        assert_eq!(wrapper.get_regex().as_ref(), &wrapper);
+
+        let wrapper_handle: RegexWrapperHandle = wrapper.clone().into();
+        assert_eq!(wrapper_handle.get_regex().as_ref(), &wrapper);
+
+        let supplier: RegexSupplierHandle = wrapper_handle;
+        assert_eq!(supplier.get_regex().as_ref(), &wrapper);
+
+        assert_eq!(supplier.get_pattern(), "foo");
+        assert_eq!(supplier.get_regex().as_str(), "foo");
     }
 }


### PR DESCRIPTION
Add comprehensive unit tests and implement `PartialEq` for `RegexWrapper`. Enhance regex utilities with trait bounds, debug implementations, and pool functionality.