### PR TITLE
Introduce OATokenizer for pretrained tokenizer management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7720,6 +7720,8 @@ dependencies = [
  "parking_lot",
  "rayon",
  "regex",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
  "tempdir",
  "tracing",
  "wordchipper-disk-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ serial_test = "^3.3"
 shellexpand = "^3.1"
 similar = "^2.7.0"
 stackvec = "^0.2.1"
+strum = "^0.27"
+strum_macros = "^0.27"
 tempdir = "^0.3"
 
 fancy-regex = { version = "0.13.0", default-features = false }

--- a/crates/wordchipper/Cargo.toml
+++ b/crates/wordchipper/Cargo.toml
@@ -53,6 +53,8 @@ std = [
     "log/std",
     "num-traits/std",
     "regex/default",
+    "dep:strum",
+    "dep:strum_macros",
 ]
 no_std = [
     "hashbrown/alloc"
@@ -91,6 +93,8 @@ regex = { workspace = true, features = ["unicode"] }
 # "std" feature deps:
 base64 = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
+strum = { workspace = true, optional = true }
+strum_macros = { workspace = true, optional = true }
 
 # "no_std" feature deps:
 hashbrown = { workspace = true, optional = true }

--- a/crates/wordchipper/src/vocab/public/openai/loaders.rs
+++ b/crates/wordchipper/src/vocab/public/openai/loaders.rs
@@ -18,9 +18,56 @@ use crate::vocab::public::openai::specials::{
     oa_gpt3_cl100k_edit_specials, oa_gpt5_o200k_harmony_specials, oa_gt5_o200k_base_specials,
 };
 use crate::vocab::utility::resource_tools::ConstUrlResource;
+use strum_macros::EnumString;
 
 /// Shared download context key.
 const OA_KEY: &str = "openai";
+
+/// `OpenAI` Pretrained Tokenizer types.
+#[derive(Clone, Debug, PartialEq, EnumString, strum_macros::Display)]
+#[non_exhaustive]
+pub enum OATokenizer {
+    /// GPT-2 "`r50k_base`" tokenizer.
+    #[strum(serialize = "r50k_base")]
+    R50kBase,
+
+    /// GPT-2 "`p50k_base`" tokenizer.
+    #[strum(serialize = "p50k_base")]
+    P50kBase,
+
+    /// GPT-2 "`p50k_edit`" tokenizer.
+    #[strum(serialize = "p50k_edit")]
+    P50kEdit,
+
+    /// GPT-3 "`cl100k_base`" tokenizer.
+    #[strum(serialize = "cl100k_base")]
+    Cl100kBase,
+
+    /// GPT-5 "`o200k_base`" tokenizer.
+    #[strum(serialize = "o200k_base")]
+    O200kBase,
+
+    /// GPT-5 "`o200k_harmony`" tokenizer.
+    #[strum(serialize = "o200k_harmony")]
+    O200kHarmony,
+}
+
+impl OATokenizer {
+    /// Load a pretrained `OpenAI` tokenizer vocabulary.
+    pub fn load<T: TokenType>(
+        &self,
+        disk_cache: &mut WordchipperDiskCache,
+    ) -> anyhow::Result<UnifiedTokenVocab<T>> {
+        match self {
+            OATokenizer::R50kBase => load_r50k_base_vocab::<T>(disk_cache),
+            OATokenizer::P50kBase => load_p50k_base_vocab::<T>(disk_cache),
+            OATokenizer::P50kEdit => load_p50k_edit_vocab::<T>(disk_cache),
+            OATokenizer::Cl100kBase => load_cl100k_base_vocab::<T>(disk_cache),
+            OATokenizer::O200kBase => load_o200k_base_vocab::<T>(disk_cache),
+            OATokenizer::O200kHarmony => load_o200k_harmony_vocab::<T>(disk_cache),
+        }
+    }
+}
 
 fn load_common_vocab<T: TokenType>(
     disk_cache: &mut WordchipperDiskCache,
@@ -121,4 +168,45 @@ pub fn load_o200k_harmony_vocab<T: TokenType>(
         OA_GPT2_R50K_WORD_PATTERN.into(),
         &oa_gpt5_o200k_harmony_specials().to_vec(),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use core::str::FromStr;
+
+    #[test]
+    fn test_oa_tokenizer() {
+        assert_eq!(OATokenizer::R50kBase.to_string(), "r50k_base");
+        assert_eq!(OATokenizer::P50kBase.to_string(), "p50k_base");
+        assert_eq!(OATokenizer::P50kEdit.to_string(), "p50k_edit");
+        assert_eq!(OATokenizer::Cl100kBase.to_string(), "cl100k_base");
+        assert_eq!(OATokenizer::O200kBase.to_string(), "o200k_base");
+        assert_eq!(OATokenizer::O200kHarmony.to_string(), "o200k_harmony");
+
+        assert_eq!(
+            OATokenizer::from_str("r50k_base").unwrap(),
+            OATokenizer::R50kBase
+        );
+        assert_eq!(
+            OATokenizer::from_str("p50k_base").unwrap(),
+            OATokenizer::P50kBase
+        );
+        assert_eq!(
+            OATokenizer::from_str("p50k_edit").unwrap(),
+            OATokenizer::P50kEdit
+        );
+        assert_eq!(
+            OATokenizer::from_str("cl100k_base").unwrap(),
+            OATokenizer::Cl100kBase
+        );
+        assert_eq!(
+            OATokenizer::from_str("o200k_base").unwrap(),
+            OATokenizer::O200kBase
+        );
+        assert_eq!(
+            OATokenizer::from_str("o200k_harmony").unwrap(),
+            OATokenizer::O200kHarmony
+        );
+    }
 }

--- a/crates/wordchipper/src/vocab/public/openai/patterns.rs
+++ b/crates/wordchipper/src/vocab/public/openai/patterns.rs
@@ -51,6 +51,7 @@ pub const OA_GPT3_CL100K_WORD_PATTERN: ConstRegexWrapperPattern =
 pub const OA_GPT5_O220K_WORD_PATTERN: ConstRegexWrapperPattern = ConstRegexWrapperPattern::Fancy(
     join_patterns!(
         r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
+        r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?",
         r"\p{N}{1,3}",
         r" ?[^\s\p{L}\p{N}]+[\r\n/]*",
         r"\s*[\r\n]+",


### PR DESCRIPTION
- Added `OATokenizer` enum to manage pretrained tokenizer types and their corresponding loading functionality.
- Integrated `strum` and `strum_macros` to enable enum serialization and string parsing.
- Updated `examples/token-cli` to utilize `OATokenizer` for `o200k_harmony` vocabulary loading.
- Expanded tokenization rules in `OA_GPT5_O220K_WORD_PATTERN` with additional patterns for comprehensive coverage.
- Implemented unit tests for `OATokenizer` to ensure functional reliability.
- Updated dependencies and Cargo features to accommodate `strum` usage.