### PR TITLE
Replace manual trait checks with centralized method

### DIFF
--- a/crates/wordchipper/src/compat/mod.rs
+++ b/crates/wordchipper/src/compat/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod ranges;
 pub mod strings;
+pub mod traits;
 
 #[cfg(feature = "std")]
 pub mod threads;

--- a/crates/wordchipper/src/compat/traits.rs
+++ b/crates/wordchipper/src/compat/traits.rs
@@ -1,0 +1,13 @@
+//! # Trait Compatibility and Utility
+
+/// Static if a type is `Send`.
+pub fn static_is_send_check<S: Send>(_: &S) {}
+
+/// Check if a type is `Sync`.
+pub fn static_is_sync_check<S: Sync>(_: &S) {}
+
+/// Check if a type is `Send` and `Sync`.
+pub fn static_is_send_sync_check<S: Send + Sync>(v: &S) {
+    static_is_send_check(v);
+    static_is_sync_check(v);
+}

--- a/crates/wordchipper/src/decoders/utility/test_utils.rs
+++ b/crates/wordchipper/src/decoders/utility/test_utils.rs
@@ -3,9 +3,10 @@
 use crate::alloc::vec;
 use crate::alloc::vec::Vec;
 use crate::compat::strings::string_from_utf8_lossy;
+use crate::compat::traits::static_is_send_sync_check;
 use crate::decoders::TokenDecoder;
 use crate::encoders::{DefaultTokenEncoder, TokenEncoder};
-use crate::types::{TokenType, check_is_send, check_is_sync};
+use crate::types::TokenType;
 use crate::vocab::{TokenVocab, UnifiedTokenVocab};
 
 /// Common Unittest for TokenDecoder implementations.
@@ -13,8 +14,7 @@ pub fn common_decoder_unit_test<T: TokenType, D: TokenDecoder<T>>(
     vocab: UnifiedTokenVocab<T>,
     decoder: &D,
 ) {
-    check_is_send(decoder);
-    check_is_sync(decoder);
+    static_is_send_sync_check(decoder);
 
     let samples = vec![
         "hello world",

--- a/crates/wordchipper/src/encoders/test_utils.rs
+++ b/crates/wordchipper/src/encoders/test_utils.rs
@@ -3,10 +3,11 @@
 use crate::alloc::string::String;
 use crate::alloc::vec;
 use crate::alloc::vec::Vec;
+use crate::compat::traits::static_is_send_sync_check;
 use crate::decoders::{DictionaryDecoder, TokenDecoder};
 use crate::encoders::TokenEncoder;
 use crate::segmentation::SegmentationConfig;
-use crate::types::{TokenType, check_is_send, check_is_sync};
+use crate::types::TokenType;
 use crate::vocab::byte_vocab::build_test_shift_byte_vocab;
 use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
 use crate::vocab::utility::testing::build_test_vocab;
@@ -29,8 +30,7 @@ pub fn common_encoder_tests<T: TokenType, E: TokenEncoder<T>>(
     vocab: UnifiedTokenVocab<T>,
     encoder: &E,
 ) {
-    check_is_send(encoder);
-    check_is_sync(encoder);
+    static_is_send_sync_check(encoder);
 
     let samples = vec![
         "hello world",
@@ -39,8 +39,7 @@ pub fn common_encoder_tests<T: TokenType, E: TokenEncoder<T>>(
     ];
 
     let decoder = DictionaryDecoder::from_unified_vocab(vocab.clone());
-    check_is_send(&decoder);
-    check_is_sync(&decoder);
+    static_is_send_sync_check(&decoder);
 
     let token_batch = encoder.try_encode_batch(&samples).unwrap();
     let decoded_strings = decoder.try_decode_batch_to_strings(&token_batch).unwrap();

--- a/crates/wordchipper/src/training/bpe_trainer.rs
+++ b/crates/wordchipper/src/training/bpe_trainer.rs
@@ -411,11 +411,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::compat::traits::static_is_send_sync_check;
     use crate::decoders::{DictionaryDecoder, TokenDecoder};
     use crate::encoders::{DefaultTokenEncoder, TokenEncoder};
     use crate::training::BinaryPairVocabTrainerOptions;
     use crate::training::bpe_trainer::MergeJob;
-    use crate::types::{check_is_send, check_is_sync};
     use crate::vocab::public::openai::patterns::OA_GPT3_CL100K_WORD_PATTERN;
     use crate::vocab::{ByteMapVocab, UnifiedTokenVocab};
     use compact_str::CompactString;
@@ -462,12 +462,10 @@ mod tests {
         let vocab: UnifiedTokenVocab<T> = trainer.train(byte_vocab.clone()).unwrap();
 
         let encoder = DefaultTokenEncoder::<T>::init(vocab.clone(), None);
-        check_is_send(&encoder);
-        check_is_sync(&encoder);
+        static_is_send_sync_check(&encoder);
 
         let decoder = DictionaryDecoder::from_unified_vocab(vocab);
-        check_is_send(&decoder);
-        check_is_sync(&decoder);
+        static_is_send_sync_check(&decoder);
 
         for sample in samples {
             let tokens = encoder.try_encode(sample).unwrap();

--- a/crates/wordchipper/src/types.rs
+++ b/crates/wordchipper/src/types.rs
@@ -72,14 +72,6 @@ mod hash_types {
 }
 pub use hash_types::*;
 
-/// Check if a type is `Send`.
-#[cfg(test)]
-pub(crate) fn check_is_send<S: Send>(_: S) {}
-
-#[cfg(test)]
-/// Check if a type is `Sync`.
-pub(crate) fn check_is_sync<S: Sync>(_: S) {}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Replaces `check_is_send` and `check_is_sync` functions with `static_is_send_sync_check`, improving code simplicity and centralizing trait checks.