### PR TITLE
Enable uv cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "bindings/python/pyproject.toml"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Enables built-in caching in `astral-sh/setup-uv` for the Python bindings CI step
- Caches uv package downloads between runs, keyed off `bindings/python/pyproject.toml`

## Test plan
- [ ] CI passes with cache miss (first run)
- [ ] CI passes with cache hit (subsequent runs)