### PR TITLE
Build abstract Tokenizer wrapper

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -9,7 +9,7 @@ use wordchipper::{
     TokenEncoder,
     UnifiedTokenVocab,
     VocabIndex,
-    WordchipperError,
+    WCError,
     disk_cache::WordchipperDiskCache,
     support::{
         slices::{inner_slice_view, inner_str_view},
@@ -18,9 +18,9 @@ use wordchipper::{
     vocab::io::save_base64_span_map_path,
 };
 
-fn to_pyerr(err: WordchipperError) -> PyErr {
+fn to_pyerr(err: WCError) -> PyErr {
     match err {
-        WordchipperError::Io(e) => PyIOError::new_err(e.to_string()),
+        WCError::Io(e) => PyIOError::new_err(e.to_string()),
         other => PyValueError::new_err(other.to_string()),
     }
 }

--- a/crates/wordchipper/src/decoders/decode_results.rs
+++ b/crates/wordchipper/src/decoders/decode_results.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::Debug;
 
-use crate::alloc::vec::Vec;
+use crate::{WCResult, alloc::vec::Vec};
 
 /// The result of decoding tokens into bytes.
 #[derive(Debug)]
@@ -55,11 +55,11 @@ where
     }
 
     /// Try to unwrap the result, returning an error if the decoding is incomplete.
-    pub fn try_result(self) -> crate::errors::WCResult<V> {
+    pub fn try_result(self) -> WCResult<V> {
         if let Some(remaining) = self.remaining
             && remaining > 0
         {
-            return Err(crate::errors::WordchipperError::IncompleteDecode { remaining });
+            return Err(crate::WCError::IncompleteDecode { remaining });
         }
         Ok(self.value)
     }
@@ -124,7 +124,7 @@ where
     }
 
     /// Try to unwrap the results, returning an error if any decoding is incomplete.
-    pub fn try_results(self) -> crate::errors::WCResult<Vec<V>> {
+    pub fn try_results(self) -> WCResult<Vec<V>> {
         self.results.into_iter().map(|r| r.try_result()).collect()
     }
 

--- a/crates/wordchipper/src/decoders/decoder_builder.rs
+++ b/crates/wordchipper/src/decoders/decoder_builder.rs
@@ -1,9 +1,9 @@
 //! `TokenDecoder` Builder
 
 use crate::{
+    TokenType,
     alloc::sync::Arc,
     decoders::{SlabIndexDecoder, TokenDecoder},
-    types::TokenType,
     vocab::UnifiedTokenVocab,
 };
 

--- a/crates/wordchipper/src/decoders/slab_index_decoder.rs
+++ b/crates/wordchipper/src/decoders/slab_index_decoder.rs
@@ -3,9 +3,10 @@
 use core::marker::PhantomData;
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::{vec, vec::Vec},
     decoders::{DecodeResult, TokenDecoder},
-    types::TokenType,
     vocab::{DEFAULT_BYTE_PER_TOKEN_RATIO, TokenSpanMap, UnifiedTokenVocab},
 };
 
@@ -112,7 +113,7 @@ impl<T: TokenType> TokenDecoder<T> for SlabIndexDecoder<T> {
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>> {
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
         let capacity = self.predicted_byte_buffer_size(tokens);
         let mut value = Vec::with_capacity(capacity);
 

--- a/crates/wordchipper/src/decoders/token_decoder.rs
+++ b/crates/wordchipper/src/decoders/token_decoder.rs
@@ -1,10 +1,11 @@
 //! # Token Decoder Trait
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::{string::String, vec::Vec},
     decoders::{BatchDecodeResult, DecodeResult},
     support::strings::string_from_utf8_lossy,
-    types::TokenType,
 };
 
 /// The common trait for `&[T] -> Vec<u8>/String>` decoders.
@@ -26,7 +27,7 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>>;
+    ) -> WCResult<DecodeResult<Vec<u8>>>;
 
     /// Decodes a batch of tokens.
     ///
@@ -38,11 +39,11 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
     fn try_decode_batch_to_bytes(
         &self,
         batch: &[&[T]],
-    ) -> crate::errors::WCResult<BatchDecodeResult<Vec<u8>>> {
+    ) -> WCResult<BatchDecodeResult<Vec<u8>>> {
         batch
             .iter()
             .map(|tokens| self.try_decode_to_bytes(tokens))
-            .collect::<crate::errors::WCResult<Vec<_>>>()
+            .collect::<WCResult<Vec<_>>>()
             .map(BatchDecodeResult::from)
     }
 
@@ -58,7 +59,7 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
     fn try_decode_to_string(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<String>> {
+    ) -> WCResult<DecodeResult<String>> {
         self.try_decode_to_bytes(tokens)
             .map(|res| res.convert(string_from_utf8_lossy))
     }
@@ -75,11 +76,11 @@ pub trait TokenDecoder<T: TokenType>: Send + Sync {
     fn try_decode_batch_to_strings(
         &self,
         batch: &[&[T]],
-    ) -> crate::errors::WCResult<BatchDecodeResult<String>> {
+    ) -> WCResult<BatchDecodeResult<String>> {
         batch
             .iter()
             .map(|tokens| self.try_decode_to_string(tokens))
-            .collect::<crate::errors::WCResult<Vec<_>>>()
+            .collect::<WCResult<Vec<_>>>()
             .map(BatchDecodeResult::from)
     }
 }

--- a/crates/wordchipper/src/decoders/token_dict_decoder.rs
+++ b/crates/wordchipper/src/decoders/token_dict_decoder.rs
@@ -1,9 +1,10 @@
 //! # Dictionary ``{ T -> Vec<u8> }`` Token Decoder
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::vec::Vec,
     decoders::{DecodeResult, TokenDecoder},
-    types::TokenType,
     vocab::{DEFAULT_BYTE_PER_TOKEN_RATIO, TokenSpanMap, UnifiedTokenVocab},
 };
 
@@ -89,7 +90,7 @@ impl<T: TokenType> TokenDecoder<T> for TokenDictDecoder<T> {
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>> {
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
         let capacity = self.predicted_byte_buffer_size(tokens);
         let mut value = Vec::with_capacity(capacity);
 

--- a/crates/wordchipper/src/decoders/utility/byte_decoder.rs
+++ b/crates/wordchipper/src/decoders/utility/byte_decoder.rs
@@ -3,9 +3,10 @@
 //! Mainly used for utility.
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::vec::Vec,
     decoders::{DecodeResult, TokenDecoder},
-    types::TokenType,
     vocab::{ByteMapVocab, DEFAULT_BYTE_PER_TOKEN_RATIO},
 };
 
@@ -47,7 +48,7 @@ impl<T: TokenType> TokenDecoder<T> for ByteDecoder<T> {
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>> {
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
         let capacity = (tokens.len() as f32 * DEFAULT_BYTE_PER_TOKEN_RATIO) as usize;
         let mut value = Vec::with_capacity(capacity);
         let mut consumed = 0;

--- a/crates/wordchipper/src/decoders/utility/pair_decoder.rs
+++ b/crates/wordchipper/src/decoders/utility/pair_decoder.rs
@@ -1,9 +1,10 @@
 //! # Pair Expansion ``{ T -> (T, T) }`` Token Decoder
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::{vec, vec::Vec},
     decoders::{DecodeResult, TokenDecoder},
-    types::TokenType,
     vocab::{ByteMapVocab, DEFAULT_BYTE_PER_TOKEN_RATIO, PairMapVocab, TokenPairMap},
 };
 
@@ -72,7 +73,7 @@ impl<T: TokenType> TokenDecoder<T> for PairExpansionDecoder<T> {
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>> {
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
         let capacity = (tokens.len() as f32 * DEFAULT_BYTE_PER_TOKEN_RATIO) as usize;
         let mut value = Vec::with_capacity(capacity);
 

--- a/crates/wordchipper/src/decoders/utility/testing.rs
+++ b/crates/wordchipper/src/decoders/utility/testing.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     TokenEncoderBuilder,
+    TokenType,
     alloc::{vec, vec::Vec},
     decoders::TokenDecoder,
     support::{strings::string_from_utf8_lossy, traits::static_is_send_sync_check},
-    types::TokenType,
     vocab::{UnifiedTokenVocab, VocabIndex},
 };
 

--- a/crates/wordchipper/src/encoders/encoder_builder.rs
+++ b/crates/wordchipper/src/encoders/encoder_builder.rs
@@ -3,13 +3,13 @@
 use core::num::NonZeroUsize;
 
 use crate::{
+    TokenType,
     alloc::{boxed::Box, sync::Arc},
     encoders::{
         TokenEncoder,
         span_encoders::{IncrementalSweepSpanEncoder, TokenSpanEncoder},
     },
     spanning::TextSpannerBuilder,
-    types::TokenType,
     vocab::UnifiedTokenVocab,
 };
 

--- a/crates/wordchipper/src/encoders/span_encoders/incremental_sweep_encoder.rs
+++ b/crates/wordchipper/src/encoders/span_encoders/incremental_sweep_encoder.rs
@@ -4,9 +4,9 @@
 //! iterates until no more merges remain.
 
 use crate::{
+    TokenType,
     alloc::vec::Vec,
     encoders::span_encoders::span_encoder::SpanEncoder,
-    types::TokenType,
     vocab::UnifiedTokenVocab,
 };
 
@@ -60,12 +60,12 @@ impl<T: TokenType> SpanEncoder<T> for IncrementalSweepSpanEncoder<T> {
 mod tests {
     use super::*;
     use crate::{
+        TokenType,
         alloc::{boxed::Box, sync::Arc},
         encoders::{
             span_encoders::TokenSpanEncoder,
             testing::{common_encoder_test_vocab, common_encoder_tests},
         },
-        types::TokenType,
     };
 
     fn test_encoder<T: TokenType>() {

--- a/crates/wordchipper/src/encoders/span_encoders/merge_heap_encoder.rs
+++ b/crates/wordchipper/src/encoders/span_encoders/merge_heap_encoder.rs
@@ -4,9 +4,9 @@
 //! iterates until no more merges remain.
 
 use crate::{
+    TokenType,
     alloc::vec::Vec,
     encoders::span_encoders::span_encoder::SpanEncoder,
-    types::TokenType,
     vocab::UnifiedTokenVocab,
 };
 
@@ -91,12 +91,12 @@ impl<T: TokenType> SpanEncoder<T> for MergeHeapSpanEncoder<T> {
 mod tests {
     use super::*;
     use crate::{
+        TokenType,
         alloc::{boxed::Box, sync::Arc},
         encoders::{
             span_encoders::TokenSpanEncoder,
             testing::{common_encoder_test_vocab, common_encoder_tests},
         },
-        types::TokenType,
     };
 
     fn test_encoder<T: TokenType>() {

--- a/crates/wordchipper/src/encoders/span_encoders/token_span_encoder.rs
+++ b/crates/wordchipper/src/encoders/span_encoders/token_span_encoder.rs
@@ -2,6 +2,7 @@ use crate::{
     TokenEncoder,
     TokenType,
     UnifiedTokenVocab,
+    WCResult,
     alloc::{boxed::Box, sync::Arc, vec::Vec},
     encoders::span_encoders::SpanEncoder,
     spanning::TextSpanner,
@@ -38,8 +39,8 @@ impl<T: TokenType> TokenSpanEncoder<T> {
 }
 
 impl<T: TokenType> TokenEncoder<T> for TokenSpanEncoder<T> {
-    fn spanner(&self) -> Arc<dyn TextSpanner> {
-        self.spanner.clone()
+    fn spanner(&self) -> &Arc<dyn TextSpanner> {
+        &self.spanner
     }
 
     fn special_vocab(&self) -> &SpecialVocab<T> {
@@ -54,7 +55,7 @@ impl<T: TokenType> TokenEncoder<T> for TokenSpanEncoder<T> {
         &self,
         text: &str,
         tokens: &mut Vec<T>,
-    ) -> crate::errors::WCResult<()> {
+    ) -> WCResult<()> {
         let mut se = (self.se_builder)();
 
         self.spanner.for_each_split_span(text, &mut |span_ref| {

--- a/crates/wordchipper/src/encoders/testing.rs
+++ b/crates/wordchipper/src/encoders/testing.rs
@@ -1,13 +1,13 @@
 //! # Encoder Test Utilities
 
 use crate::{
+    TokenType,
     alloc::{string::String, sync::Arc, vec, vec::Vec},
     decoders::{TokenDecoder, TokenDictDecoder},
     encoders::TokenEncoder,
     pretrained::openai::OA_CL100K_BASE_PATTERN,
     spanning::TextSpanningConfig,
     support::{slices::inner_slice_view, traits::static_is_send_sync_check},
-    types::TokenType,
     vocab::{
         UnifiedTokenVocab,
         VocabIndex,

--- a/crates/wordchipper/src/encoders/token_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_encoder.rs
@@ -1,9 +1,10 @@
 //! # Token Encoder Trait
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::{sync::Arc, vec::Vec},
     spanning::TextSpanner,
-    types::TokenType,
     vocab::SpecialVocab,
 };
 
@@ -17,7 +18,7 @@ use crate::{
 /// when there is a conflict.
 pub trait TokenEncoder<T: TokenType>: Send + Sync {
     /// Return the attached text segmentor.
-    fn spanner(&self) -> Arc<dyn TextSpanner>;
+    fn spanner(&self) -> &Arc<dyn TextSpanner>;
 
     /// Return the attached special vocab.
     ///
@@ -55,7 +56,7 @@ pub trait TokenEncoder<T: TokenType>: Send + Sync {
         &self,
         text: &str,
         tokens: &mut Vec<T>,
-    ) -> crate::errors::WCResult<()>;
+    ) -> WCResult<()>;
 
     /// Encode text into tokens, returning an error if the encoding fails.
     ///
@@ -67,7 +68,7 @@ pub trait TokenEncoder<T: TokenType>: Send + Sync {
     fn try_encode(
         &self,
         text: &str,
-    ) -> crate::errors::WCResult<Vec<T>> {
+    ) -> WCResult<Vec<T>> {
         let capacity = self.expected_token_count(text) * 115 / 100;
         let mut tokens = Vec::with_capacity(capacity);
 
@@ -85,7 +86,7 @@ pub trait TokenEncoder<T: TokenType>: Send + Sync {
     fn try_encode_batch(
         &self,
         batch: &[&str],
-    ) -> crate::errors::WCResult<Vec<Vec<T>>> {
+    ) -> WCResult<Vec<Vec<T>>> {
         batch.iter().map(|s| self.try_encode(s)).collect()
     }
 }

--- a/crates/wordchipper/src/errors.rs
+++ b/crates/wordchipper/src/errors.rs
@@ -4,7 +4,7 @@ use crate::alloc::string::String;
 
 /// Errors from wordchipper operations.
 #[derive(Debug, thiserror::Error)]
-pub enum WordchipperError {
+pub enum WCError {
     /// Vocab size exceeds the capacity of the target token type.
     #[error("vocab size ({size}) exceeds token type capacity")]
     VocabSizeOverflow {
@@ -49,4 +49,4 @@ pub enum WordchipperError {
 }
 
 /// Result type for wordchipper operations.
-pub type WCResult<T> = core::result::Result<T, WordchipperError>;
+pub type WCResult<T> = core::result::Result<T, WCError>;

--- a/crates/wordchipper/src/lib.rs
+++ b/crates/wordchipper/src/lib.rs
@@ -109,6 +109,7 @@ pub mod support;
 pub mod vocab;
 
 mod errors;
+mod tokenizer;
 mod types;
 
 #[doc(inline)]
@@ -120,6 +121,8 @@ pub use errors::*;
 #[doc(inline)]
 #[cfg(feature = "download")]
 pub use pretrained::{get_model, list_models};
+#[doc(inline)]
+pub use tokenizer::*;
 #[doc(inline)]
 pub use types::*;
 #[doc(inline)]

--- a/crates/wordchipper/src/pretrained/load_by_name.rs
+++ b/crates/wordchipper/src/pretrained/load_by_name.rs
@@ -1,7 +1,8 @@
 use crate::{
     UnifiedTokenVocab,
+    WCError,
+    WCResult,
     alloc::{string::String, vec::Vec},
-    errors::WordchipperError,
     pretrained::openai::OATokenizer,
     support::resources::ResourceLoader,
 };
@@ -12,7 +13,7 @@ pub struct ConstPretrainedHook {
     pub aliases: &'static [&'static str],
 
     /// A function that loads the pretrained model.
-    pub load: fn(&str, &mut dyn ResourceLoader) -> crate::errors::WCResult<UnifiedTokenVocab<u32>>,
+    pub load: fn(&str, &mut dyn ResourceLoader) -> WCResult<UnifiedTokenVocab<u32>>,
 }
 
 const PRETRAINED_HOOKS: &[ConstPretrainedHook] = &[
@@ -46,14 +47,14 @@ const PRETRAINED_HOOKS: &[ConstPretrainedHook] = &[
 pub fn get_model(
     name: &str,
     loader: &mut dyn ResourceLoader,
-) -> crate::errors::WCResult<UnifiedTokenVocab<u32>> {
+) -> WCResult<UnifiedTokenVocab<u32>> {
     for hook in PRETRAINED_HOOKS {
         if hook.aliases.contains(&name) {
             return (hook.load)(name, loader);
         }
     }
 
-    Err(WordchipperError::External(crate::alloc::format!(
+    Err(WCError::External(crate::alloc::format!(
         "Unable to load pretrained model: {name}"
     )))
 }

--- a/crates/wordchipper/src/pretrained/openai/factories.rs
+++ b/crates/wordchipper/src/pretrained/openai/factories.rs
@@ -5,6 +5,8 @@ use std::{io::BufRead, path::Path};
 #[cfg(feature = "download")]
 use crate::support::resources::ResourceLoader;
 use crate::{
+    TokenType,
+    WCResult,
     pretrained::openai::{
         OA_CL100K_BASE_PATTERN,
         OA_O200K_BASE_PATTERN,
@@ -27,7 +29,6 @@ use crate::{
     },
     spanning::TextSpanningConfig,
     support::{regex::RegexPattern, resources::ConstKeyedResource},
-    types::TokenType,
     vocab::{UnifiedTokenVocab, utility::factories::ConstVocabularyFactory},
 };
 
@@ -104,7 +105,7 @@ impl OATokenizer {
     pub fn load_vocab<T: TokenType>(
         &self,
         loader: &mut dyn ResourceLoader,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         self.factory().load_vocab(loader)
     }
 
@@ -112,7 +113,7 @@ impl OATokenizer {
     pub fn load_path<T: TokenType>(
         &self,
         path: impl AsRef<Path>,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         self.factory().load_vocab_path(path)
     }
 
@@ -120,7 +121,7 @@ impl OATokenizer {
     pub fn read_vocab<T: TokenType, R: BufRead>(
         &self,
         reader: R,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         self.factory().read_vocab(reader)
     }
 }

--- a/crates/wordchipper/src/pretrained/openai/spanning.rs
+++ b/crates/wordchipper/src/pretrained/openai/spanning.rs
@@ -1,6 +1,7 @@
 //! # Spanning Configuration for `OpenAI` Tokenizers
 
 use crate::{
+    TokenType,
     pretrained::openai::{
         OA_CL100K_BASE_PATTERN,
         OA_O200K_BASE_PATTERN,
@@ -9,7 +10,6 @@ use crate::{
         specials,
     },
     spanning::TextSpanningConfig,
-    types::TokenType,
 };
 /// Get the [`TextSpanningConfig`] for the "`r50k_base`" pretrained vocabulary.
 pub fn oa_r50k_base_spanning_config<T: TokenType>() -> TextSpanningConfig<T> {

--- a/crates/wordchipper/src/pretrained/openai/specials.rs
+++ b/crates/wordchipper/src/pretrained/openai/specials.rs
@@ -1,12 +1,12 @@
 //! `OpenAI` Tokenizer Special Tokens.
 
 use crate::{
+    TokenType,
     alloc::{
         string::{String, ToString},
         vec::Vec,
     },
     declare_carrot_special,
-    types::TokenType,
     vocab::utility::{ToTokenList, format_reserved_carrot},
 };
 

--- a/crates/wordchipper/src/spanning/spanning_config.rs
+++ b/crates/wordchipper/src/spanning/spanning_config.rs
@@ -1,5 +1,5 @@
 //! # Text Spanner Configuration
-use crate::{support::regex::RegexPattern, types::TokenType, vocab::SpecialVocab};
+use crate::{TokenType, WCResult, support::regex::RegexPattern, vocab::SpecialVocab};
 
 /// Description of text spanning configuration.
 ///
@@ -92,7 +92,7 @@ impl<T: TokenType> TextSpanningConfig<T> {
     }
 
     /// Convert to a different token type.
-    pub fn to_token_type<G: TokenType>(&self) -> crate::errors::WCResult<TextSpanningConfig<G>> {
+    pub fn to_token_type<G: TokenType>(&self) -> WCResult<TextSpanningConfig<G>> {
         Ok(TextSpanningConfig::<G> {
             pattern: self.pattern.clone(),
             specials: self.specials.to_token_type()?,

--- a/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
+++ b/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
@@ -1,9 +1,10 @@
 //! # Parallel Decoder
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::sync::Arc,
     decoders::{BatchDecodeResult, DecodeResult, TokenDecoder},
-    types::TokenType,
 };
 
 /// Batch-Level Parallel Decoder Wrapper.
@@ -42,33 +43,33 @@ where
     fn try_decode_to_bytes(
         &self,
         tokens: &[T],
-    ) -> crate::errors::WCResult<DecodeResult<Vec<u8>>> {
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
         self.inner.try_decode_to_bytes(tokens)
     }
 
     fn try_decode_batch_to_bytes(
         &self,
         batch: &[&[T]],
-    ) -> crate::errors::WCResult<BatchDecodeResult<Vec<u8>>> {
+    ) -> WCResult<BatchDecodeResult<Vec<u8>>> {
         use rayon::prelude::*;
 
         batch
             .par_iter()
             .map(|tokens| self.try_decode_to_bytes(tokens))
-            .collect::<crate::errors::WCResult<Vec<_>>>()
+            .collect::<WCResult<Vec<_>>>()
             .map(BatchDecodeResult::from)
     }
 
     fn try_decode_batch_to_strings(
         &self,
         batch: &[&[T]],
-    ) -> crate::errors::WCResult<BatchDecodeResult<String>> {
+    ) -> WCResult<BatchDecodeResult<String>> {
         use rayon::prelude::*;
 
         batch
             .par_iter()
             .map(|tokens| self.try_decode_to_string(tokens))
-            .collect::<crate::errors::WCResult<Vec<_>>>()
+            .collect::<WCResult<Vec<_>>>()
             .map(BatchDecodeResult::from)
     }
 }

--- a/crates/wordchipper/src/support/concurrency/rayon/rayon_encoder.rs
+++ b/crates/wordchipper/src/support/concurrency/rayon/rayon_encoder.rs
@@ -1,10 +1,11 @@
 //! # Parallel Encoder
 
 use crate::{
+    TokenType,
+    WCResult,
     alloc::sync::Arc,
     encoders::TokenEncoder,
     spanning::TextSpanner,
-    types::TokenType,
     vocab::SpecialVocab,
 };
 
@@ -41,7 +42,7 @@ impl<T> TokenEncoder<T> for ParallelRayonEncoder<T>
 where
     T: TokenType,
 {
-    fn spanner(&self) -> Arc<dyn TextSpanner> {
+    fn spanner(&self) -> &Arc<dyn TextSpanner> {
         self.inner.spanner()
     }
 
@@ -53,17 +54,17 @@ where
         &self,
         text: &str,
         tokens: &mut Vec<T>,
-    ) -> crate::errors::WCResult<()> {
+    ) -> WCResult<()> {
         self.inner.try_encode_append(text, tokens)
     }
 
     fn try_encode_batch(
         &self,
         batch: &[&str],
-    ) -> crate::errors::WCResult<Vec<Vec<T>>> {
+    ) -> WCResult<Vec<Vec<T>>> {
         use rayon::prelude::*;
 
-        let results: Vec<crate::errors::WCResult<Vec<T>>> = batch
+        let results: Vec<WCResult<Vec<T>>> = batch
             .par_iter()
             .map(|text| self.inner.try_encode(text))
             .collect();
@@ -76,11 +77,11 @@ where
 mod tests {
     use super::*;
     use crate::{
+        TokenType,
         encoders::{
             TokenEncoder,
             testing::{common_encoder_test_vocab, common_encoder_tests},
         },
-        types::TokenType,
     };
 
     fn test_encoder<T: TokenType>() {

--- a/crates/wordchipper/src/support/resources/resource_loader.rs
+++ b/crates/wordchipper/src/support/resources/resource_loader.rs
@@ -13,7 +13,7 @@ pub trait ResourceLoader {
     fn load_resource_path(
         &mut self,
         resource: &KeyedResource,
-    ) -> crate::errors::WCResult<PathBuf>;
+    ) -> crate::WCResult<PathBuf>;
 }
 
 #[cfg(feature = "download")]
@@ -22,8 +22,8 @@ impl ResourceLoader for crate::disk_cache::WordchipperDiskCache {
     fn load_resource_path(
         &mut self,
         resource: &KeyedResource,
-    ) -> crate::errors::WCResult<PathBuf> {
+    ) -> crate::WCResult<PathBuf> {
         self.load_cached_path(&resource.key, &resource.resource.urls, true)
-            .map_err(|e| crate::errors::WordchipperError::External(e.to_string()))
+            .map_err(|e| crate::WCError::External(e.to_string()))
     }
 }

--- a/crates/wordchipper/src/tokenizer.rs
+++ b/crates/wordchipper/src/tokenizer.rs
@@ -1,0 +1,117 @@
+//! # Combined Tokenizer
+
+use crate::{
+    TokenDecoder,
+    TokenEncoder,
+    TokenType,
+    UnifiedTokenVocab,
+    WCResult,
+    alloc::{string::String, sync::Arc, vec::Vec},
+    decoders::{BatchDecodeResult, DecodeResult},
+    spanning::TextSpanner,
+};
+
+/// Unified Tokenizer.
+///
+/// Combines:
+///  * [`UnifiedTokenVocab`],
+///  * [`TokenEncoder`], and
+///  * [`TokenDecoder`] wrappers.
+#[derive(Clone)]
+pub struct Tokenizer<T: TokenType> {
+    vocab: Arc<UnifiedTokenVocab<T>>,
+    encoder: Arc<dyn TokenEncoder<T>>,
+    decoder: Arc<dyn TokenDecoder<T>>,
+}
+
+impl<T: TokenType> Tokenizer<T> {
+    /// Create a new tokenizer.
+    pub fn new(
+        vocab: Arc<UnifiedTokenVocab<T>>,
+        encoder: Arc<dyn TokenEncoder<T>>,
+        decoder: Arc<dyn TokenDecoder<T>>,
+    ) -> Self {
+        Self {
+            vocab,
+            encoder,
+            decoder,
+        }
+    }
+
+    /// Get the underlying vocabulary.
+    pub fn vocab(&self) -> &Arc<UnifiedTokenVocab<T>> {
+        &self.vocab
+    }
+
+    /// Get the underlying encoder.
+    pub fn encoder(&self) -> &Arc<dyn TokenEncoder<T>> {
+        &self.encoder
+    }
+
+    /// Get the underlying decoder.
+    pub fn decoder(&self) -> &Arc<dyn TokenDecoder<T>> {
+        &self.decoder
+    }
+}
+
+impl<T: TokenType> TokenEncoder<T> for Tokenizer<T> {
+    fn spanner(&self) -> &Arc<dyn TextSpanner> {
+        self.encoder.spanner()
+    }
+
+    fn special_vocab(&self) -> &crate::vocab::SpecialVocab<T> {
+        self.encoder.special_vocab()
+    }
+
+    fn try_encode_append(
+        &self,
+        text: &str,
+        tokens: &mut Vec<T>,
+    ) -> WCResult<()> {
+        self.encoder.try_encode_append(text, tokens)
+    }
+
+    fn try_encode(
+        &self,
+        text: &str,
+    ) -> WCResult<Vec<T>> {
+        self.encoder.try_encode(text)
+    }
+
+    fn try_encode_batch(
+        &self,
+        batch: &[&str],
+    ) -> WCResult<Vec<Vec<T>>> {
+        self.encoder.try_encode_batch(batch)
+    }
+}
+
+impl<T: TokenType> TokenDecoder<T> for Tokenizer<T> {
+    fn try_decode_to_bytes(
+        &self,
+        tokens: &[T],
+    ) -> WCResult<DecodeResult<Vec<u8>>> {
+        self.decoder.try_decode_to_bytes(tokens)
+    }
+
+    fn try_decode_batch_to_bytes(
+        &self,
+        batch: &[&[T]],
+    ) -> WCResult<BatchDecodeResult<Vec<u8>>> {
+        self.decoder.try_decode_batch_to_bytes(batch)
+    }
+
+    fn try_decode_to_string(
+        &self,
+        tokens: &[T],
+    ) -> WCResult<DecodeResult<String>> {
+        self.decoder.try_decode_to_string(tokens)
+    }
+
+    fn try_decode_batch_to_strings(
+        &self,
+        batch: &[&[T]],
+    ) -> WCResult<BatchDecodeResult<String>> {
+        self.decoder.try_decode_batch_to_strings(batch)
+    }
+}

--- a/crates/wordchipper/src/training/bpe_trainer.rs
+++ b/crates/wordchipper/src/training/bpe_trainer.rs
@@ -6,6 +6,7 @@ use compact_str::CompactString;
 use dary_heap::OctonaryHeap;
 
 use crate::{
+    WCResult,
     support::regex::RegexPattern,
     training::{
         CountType,
@@ -240,7 +241,7 @@ where
     fn train_basic_pairs<T>(
         self,
         byte_vocab: ByteMapVocab<T>,
-    ) -> crate::errors::WCResult<TrainResults<T>>
+    ) -> WCResult<TrainResults<T>>
     where
         T: TokenType,
         C: CountType,
@@ -253,7 +254,7 @@ where
         self.options
             .pattern
             .compile()
-            .map_err(|e| crate::errors::WordchipperError::External(e.to_string()))?;
+            .map_err(|e| crate::WCError::External(e.to_string()))?;
 
         let mut pairs: PairTokenMap<T> = WCHashMap::with_capacity(num_merges);
 
@@ -402,7 +403,7 @@ where
     pub fn train<T>(
         self,
         byte_vocab: ByteMapVocab<T>,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>>
+    ) -> WCResult<UnifiedTokenVocab<T>>
     where
         T: TokenType,
         C: CountType,

--- a/crates/wordchipper/src/training/mod.rs
+++ b/crates/wordchipper/src/training/mod.rs
@@ -51,7 +51,7 @@
 //!     S: AsRef<str>,
 //! {
 //!     // We can pick any unsigned integer type > vocab_size;
-//!     // See [`wordchipper::types::TokenType`].
+//!     // See [`wordchipper::TokenType`].
 //!     type T = u32;
 //!     type K = String;
 //!     type C = u64;

--- a/crates/wordchipper/src/vocab/byte_vocab.rs
+++ b/crates/wordchipper/src/vocab/byte_vocab.rs
@@ -3,6 +3,7 @@
 use core::fmt::Debug;
 
 use crate::{
+    WCResult,
     alloc::{vec, vec::Vec},
     types::{TokenType, WCHashSet},
     vocab::{ByteTokenArray, ByteTokenMap, TokenByteMap, VocabIndex},
@@ -107,7 +108,7 @@ impl<T: TokenType> ByteMapVocab<T> {
     }
 
     /// Convert to a different token type.
-    pub fn to_token_type<G: TokenType>(&self) -> crate::errors::WCResult<ByteMapVocab<G>> {
+    pub fn to_token_type<G: TokenType>(&self) -> WCResult<ByteMapVocab<G>> {
         Ok(ByteMapVocab::<G>::from_byte_to_token(
             &self
                 .byte_tokens

--- a/crates/wordchipper/src/vocab/io/base64_vocab.rs
+++ b/crates/wordchipper/src/vocab/io/base64_vocab.rs
@@ -9,9 +9,10 @@ use std::{
 use base64::{Engine, prelude::BASE64_STANDARD};
 
 use crate::{
-    errors::WordchipperError,
+    TokenType,
+    WCError,
+    WCResult,
     spanning::TextSpanningConfig,
-    types::TokenType,
     vocab::{SpanMapVocab, UnifiedTokenVocab, vocab_types::SpanTokenMap},
 };
 
@@ -24,7 +25,7 @@ use crate::{
 pub fn load_base64_unified_vocab_path<T: TokenType>(
     path: impl AsRef<Path>,
     spanning: TextSpanningConfig<T>,
-) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+) -> WCResult<UnifiedTokenVocab<T>> {
     let reader = BufReader::new(File::open(path)?);
     read_base64_unified_vocab(reader, spanning)
 }
@@ -38,7 +39,7 @@ pub fn load_base64_unified_vocab_path<T: TokenType>(
 pub fn read_base64_unified_vocab<T: TokenType, R: BufRead>(
     reader: R,
     spanning: TextSpanningConfig<T>,
-) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+) -> WCResult<UnifiedTokenVocab<T>> {
     UnifiedTokenVocab::from_span_vocab(spanning, read_base64_span_map(reader)?.into())
 }
 
@@ -51,7 +52,7 @@ pub fn read_base64_unified_vocab<T: TokenType, R: BufRead>(
 ///
 /// # Arguments
 /// * `path` - the path to the vocabulary file.
-pub fn load_base64_span_vocab_path<T, P>(path: P) -> crate::errors::WCResult<SpanMapVocab<T>>
+pub fn load_base64_span_vocab_path<T, P>(path: P) -> WCResult<SpanMapVocab<T>>
 where
     T: TokenType,
     P: AsRef<Path>,
@@ -68,7 +69,7 @@ where
 ///
 /// # Arguments
 /// * `path` - the path to the vocabulary file.
-pub fn load_base64_span_map_path<T, P>(path: P) -> crate::errors::WCResult<SpanTokenMap<T>>
+pub fn load_base64_span_map_path<T, P>(path: P) -> WCResult<SpanTokenMap<T>>
 where
     T: TokenType,
     P: AsRef<Path>,
@@ -87,7 +88,7 @@ where
 /// # Arguments
 /// * `span_map` - the vocabulary to extend.
 /// * `reader` - the line reader.
-pub fn read_base64_span_map<T, R>(reader: R) -> crate::errors::WCResult<SpanTokenMap<T>>
+pub fn read_base64_span_map<T, R>(reader: R) -> WCResult<SpanTokenMap<T>>
 where
     T: TokenType,
     R: BufRead,
@@ -104,12 +105,12 @@ where
 
         let span = BASE64_STANDARD
             .decode(parts[0])
-            .map_err(|e| WordchipperError::Parse(e.to_string()))?;
+            .map_err(|e| WCError::Parse(e.to_string()))?;
 
         let id: u64 = parts[1]
             .parse()
-            .map_err(|e: core::num::ParseIntError| WordchipperError::Parse(e.to_string()))?;
-        let token = T::from_u64(id).ok_or(WordchipperError::TokenOutOfRange)?;
+            .map_err(|e: core::num::ParseIntError| WCError::Parse(e.to_string()))?;
+        let token = T::from_u64(id).ok_or(WCError::TokenOutOfRange)?;
 
         vocab.insert(span, token);
     }
@@ -130,7 +131,7 @@ where
 pub fn save_base64_span_map_path<T: TokenType, P: AsRef<Path>>(
     span_map: &SpanTokenMap<T>,
     path: P,
-) -> crate::errors::WCResult<()> {
+) -> WCResult<()> {
     let mut writer = BufWriter::new(File::create(path)?);
     write_base64_span_map(span_map, &mut writer)
 }
@@ -148,7 +149,7 @@ pub fn save_base64_span_map_path<T: TokenType, P: AsRef<Path>>(
 pub fn write_base64_span_map<T, W>(
     span_map: &SpanTokenMap<T>,
     writer: &mut W,
-) -> crate::errors::WCResult<()>
+) -> WCResult<()>
 where
     T: TokenType,
     W: Write,

--- a/crates/wordchipper/src/vocab/span_vocab.rs
+++ b/crates/wordchipper/src/vocab/span_vocab.rs
@@ -1,6 +1,7 @@
 //! # Word Map ``{ Vec<u8> -> T }`` Token Vocabulary
 
 use crate::{
+    WCResult,
     alloc::vec::Vec,
     types::{TokenType, WCHashMap, WCHashSet},
     vocab::{
@@ -54,7 +55,7 @@ pub fn byte_map_from_span_map<T: TokenType>(span_map: &SpanTokenMap<T>) -> ByteT
 pub fn try_validate_span_map<T>(
     byte_vocab: &ByteMapVocab<T>,
     span_map: &SpanTokenMap<T>,
-) -> crate::errors::WCResult<()>
+) -> WCResult<()>
 where
     T: TokenType,
 {
@@ -64,13 +65,11 @@ where
         if let Some(&map_token) = span_map.get(&span)
             && token != map_token
         {
-            return Err(crate::errors::WordchipperError::VocabConflict(
-                crate::alloc::format!(
-                    "ByteTable disagrees with span_map for {b:0x?}: {:?} != {:?}",
-                    token,
-                    map_token
-                ),
-            ));
+            return Err(crate::WCError::VocabConflict(crate::alloc::format!(
+                "ByteTable disagrees with span_map for {b:0x?}: {:?} != {:?}",
+                token,
+                map_token
+            )));
         }
     }
 
@@ -140,7 +139,7 @@ impl<T: TokenType> SpanMapVocab<T> {
     pub fn new(
         byte_vocab: ByteMapVocab<T>,
         mut span_map: SpanTokenMap<T>,
-    ) -> crate::errors::WCResult<Self> {
+    ) -> WCResult<Self> {
         try_validate_span_map(&byte_vocab, &span_map)?;
 
         span_map.extend(byte_vocab.span_pairs());
@@ -154,7 +153,7 @@ impl<T: TokenType> SpanMapVocab<T> {
     }
 
     /// Convert to a different token type.
-    pub fn to_token_type<G: TokenType>(&self) -> crate::errors::WCResult<SpanMapVocab<G>> {
+    pub fn to_token_type<G: TokenType>(&self) -> WCResult<SpanMapVocab<G>> {
         if let Some(max) = self.max_token() {
             try_vocab_size::<G>(max.to_usize().unwrap())?;
         }

--- a/crates/wordchipper/src/vocab/special_vocab.rs
+++ b/crates/wordchipper/src/vocab/special_vocab.rs
@@ -1,6 +1,7 @@
 //! # Special Words Vocabulary
 
 use crate::{
+    WCResult,
     alloc::vec::Vec,
     support::{
         regex::{RegexPattern, alternate_choice_regex_pattern},
@@ -53,7 +54,7 @@ impl<T: TokenType> SpecialVocab<T> {
     }
 
     /// Convert to a different token type.
-    pub fn to_token_type<G: TokenType>(&self) -> crate::errors::WCResult<SpecialVocab<G>> {
+    pub fn to_token_type<G: TokenType>(&self) -> WCResult<SpecialVocab<G>> {
         if let Some(max) = self.max_token() {
             try_vocab_size::<G>(max.to_usize().unwrap())?;
         }

--- a/crates/wordchipper/src/vocab/utility/factories.rs
+++ b/crates/wordchipper/src/vocab/utility/factories.rs
@@ -8,17 +8,19 @@ use std::{
 };
 
 #[cfg(feature = "std")]
+use crate::WCResult;
+#[cfg(feature = "std")]
 use crate::support::resources::ResourceLoader;
 #[cfg(feature = "std")]
 use crate::vocab::UnifiedTokenVocab;
 use crate::{
+    TokenType,
     alloc::{string::String, vec::Vec},
     spanning::TextSpanningConfig,
     support::{
         regex::{ConstRegexPattern, RegexPattern},
         resources::ConstKeyedResource,
     },
-    types::TokenType,
 };
 
 /// A pretrained tokenizer bundle.
@@ -60,7 +62,7 @@ impl ConstVocabularyFactory {
     fn fetch_resource(
         &self,
         loader: &mut dyn ResourceLoader,
-    ) -> crate::errors::WCResult<PathBuf> {
+    ) -> WCResult<PathBuf> {
         let res: crate::support::resources::KeyedResource = self.resource.clone().into();
         loader.load_resource_path(&res)
     }
@@ -70,7 +72,7 @@ impl ConstVocabularyFactory {
     pub fn load_vocab<T: TokenType>(
         &self,
         loader: &mut dyn ResourceLoader,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         let path = self.fetch_resource(loader)?;
         self.load_vocab_path(path)
     }
@@ -80,7 +82,7 @@ impl ConstVocabularyFactory {
     pub fn load_vocab_path<T: TokenType>(
         &self,
         path: impl AsRef<Path>,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         let reader = BufReader::new(File::open(path)?);
         self.read_vocab(reader)
     }
@@ -90,7 +92,7 @@ impl ConstVocabularyFactory {
     pub fn read_vocab<T: TokenType, R: BufRead>(
         &self,
         reader: R,
-    ) -> crate::errors::WCResult<UnifiedTokenVocab<T>> {
+    ) -> WCResult<UnifiedTokenVocab<T>> {
         crate::vocab::io::read_base64_unified_vocab(reader, self.spanning_config())
     }
 }

--- a/crates/wordchipper/src/vocab/utility/testing/mod.rs
+++ b/crates/wordchipper/src/vocab/utility/testing/mod.rs
@@ -1,9 +1,9 @@
 //! # Vocab Testing Tools
 
 use crate::{
+    TokenType,
     alloc::vec::Vec,
     spanning::TextSpanningConfig,
-    types::TokenType,
     vocab::{ByteMapVocab, SpanMapVocab, SpanTokenMap, UnifiedTokenVocab},
 };
 

--- a/crates/wordchipper/src/vocab/utility/token_list.rs
+++ b/crates/wordchipper/src/vocab/utility/token_list.rs
@@ -1,11 +1,11 @@
 //! # Token List Utility
 
 use crate::{
+    TokenType,
     alloc::{
         string::{String, ToString},
         vec::Vec,
     },
-    types::TokenType,
 };
 
 /// A utility trait to generate a listing of tokens.

--- a/crates/wordchipper/src/vocab/utility/validators.rs
+++ b/crates/wordchipper/src/vocab/utility/validators.rs
@@ -1,15 +1,15 @@
 //! Validators for various configuration options.
-use crate::{errors::WordchipperError, types::TokenType};
+use crate::{TokenType, WCError, WCResult};
 
 /// The size of the u8 space.
 pub const U8_SIZE: usize = u8::MAX as usize + 1;
 
 /// Validates and returns the vocabulary size, ensuring it's at least the size of the u8 space.
-pub fn try_vocab_size<T: TokenType>(vocab_size: usize) -> crate::errors::WCResult<usize> {
+pub fn try_vocab_size<T: TokenType>(vocab_size: usize) -> WCResult<usize> {
     if T::from_usize(vocab_size - 1).is_none() {
-        Err(WordchipperError::VocabSizeOverflow { size: vocab_size })
+        Err(WCError::VocabSizeOverflow { size: vocab_size })
     } else if vocab_size < U8_SIZE {
-        Err(WordchipperError::VocabSizeTooSmall { size: vocab_size })
+        Err(WCError::VocabSizeTooSmall { size: vocab_size })
     } else {
         Ok(vocab_size)
     }

--- a/examples/sample-timer/src/wordchipper_support.rs
+++ b/examples/sample-timer/src/wordchipper_support.rs
@@ -25,7 +25,7 @@ impl<T: TokenType> WordchipperEngine<T> {
         }
     }
 
-    pub fn spanner(&self) -> Arc<dyn TextSpanner> {
+    pub fn spanner(&self) -> &Arc<dyn TextSpanner> {
         self.encoder.spanner()
     }
 }


### PR DESCRIPTION
This pull request introduces an abstract Tokenizer wrapper, simplifying type imports and renaming error/result types for improved clarity and maintainability.