### PR TITLE
Refactor concurrency handling for `TokenEncoderBuilder` and `SpanEncoderSelector`

### DIFF
--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder_selector.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder_selector.rs
@@ -27,19 +27,20 @@ use crate::{
 )]
 #[non_exhaustive]
 pub enum SpanEncoderSelector {
-    /// The canonical best Default encoder.
+    /// This is the canonical best concurrent encoder.
     ///
-    /// Users should, in general, prefer to use this encoder.
+    /// It is benchmarked to be the fastest and most efficient encoder for concurrent use.
     ///
-    /// As improved encoders are developed, this will remain the evergreen
-    /// label for "the good one". We expose this, rather than making
-    /// a particular encoder the marked default, so that serializations
-    /// of this policy into config files will convey "use the default",
-    /// rather than "use the default as of the time this config was saved".
+    /// This is currently an alias for: [`MergeHeap`](`Self::MergeHeap`)
+    #[default]
+    ConcurrentDefault,
+
+    /// This the canonical best single-threaded encoder.
+    ///
+    /// It is benchmarked to be the fastest and most efficient encoder for single-threaded use.
     ///
     /// This is currently an alias for: [`PriorityMerge`](`Self::PriorityMerge`)
-    #[default]
-    Default,
+    SingleThreadDefault,
 
     /// The canonical reference encoder, [`BufferSweepSpanEncoder`].
     ///
@@ -73,8 +74,10 @@ impl SpanEncoderSelector {
                 Arc::new(|| Box::new(BufferSweepSpanEncoder::<T>::default()))
             }
             TailSweep => Arc::new(|| Box::new(TailSweepSpanEncoder::<T>::default())),
-            MergeHeap => Arc::new(|| Box::new(MergeHeapSpanEncoder::<T>::default())),
-            Default | PriorityMerge => {
+            ConcurrentDefault | MergeHeap => {
+                Arc::new(|| Box::new(MergeHeapSpanEncoder::<T>::default()))
+            }
+            SingleThreadDefault | PriorityMerge => {
                 Arc::new(|| Box::new(PriorityMergeSpanEncoder::<T>::default()))
             }
         }

--- a/crates/wordchipper/src/encoders/token_span_encoder/token_span_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/token_span_encoder.rs
@@ -28,14 +28,6 @@ where
 }
 
 impl<T: TokenType> TokenSpanEncoder<T> {
-    /// Create a new encoder using the default [`SpanEncoderSelector`].
-    pub fn new(
-        spanner: Arc<dyn TextSpanner>,
-        vocab: Arc<UnifiedTokenVocab<T>>,
-    ) -> Self {
-        Self::new_with_selector(spanner, vocab, SpanEncoderSelector::Default)
-    }
-
     /// Create a new encoder using the selected [`SpanEncoder`].
     pub fn new_with_selector(
         spanner: Arc<dyn TextSpanner>,


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Refactor `SpanEncoderSelector`:** Replaced the `Default` encoder with two distinct options—`ConcurrentDefault` and `SingleThreadDefault`.
- **Enhance concurrency in `TokenEncoderBuilder`:** Added methods to configure and query concurrency settings (`set_concurrent`, `is_concurrent`).
- **Dynamic span encoder selection:** Updated `effective_span_encoder` to choose encoders dynamically based on concurrency configuration.

These changes improve flexibility and clarity in handling concurrency settings.