### PR TITLE
Add accelerated lexer support and update benchmarks

### DIFF
--- a/crates/wordchipper-bench/benches/encoding_parallel.rs
+++ b/crates/wordchipper-bench/benches/encoding_parallel.rs
@@ -78,10 +78,12 @@ mod wordchipper {
         bencher: Bencher,
         oatok: OATokenizer,
         selector: SpanEncoderSelector,
+        accelerated: bool,
     ) {
         let strs = BATCH.strs();
 
         let encoder = wordchipper_bench::encoder_builder::<u32>(oatok, selector)
+            .with_accelerated_lexers(accelerated)
             .with_parallel(true)
             .build();
 
@@ -99,6 +101,7 @@ mod wordchipper {
                 bencher,
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
             )
         }
 
@@ -108,6 +111,27 @@ mod wordchipper {
                 bencher,
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
+            )
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
+            )
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
             )
         }
     }
@@ -121,6 +145,7 @@ mod wordchipper {
                 bencher,
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
             )
         }
 
@@ -130,6 +155,27 @@ mod wordchipper {
                 bencher,
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
+            )
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
+            )
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
             )
         }
     }
@@ -143,6 +189,7 @@ mod wordchipper {
                 bencher,
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
             )
         }
 
@@ -152,6 +199,27 @@ mod wordchipper {
                 bencher,
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
+            )
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
+            )
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
             )
         }
     }
@@ -165,6 +233,7 @@ mod wordchipper {
                 bencher,
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
             )
         }
 
@@ -174,6 +243,27 @@ mod wordchipper {
                 bencher,
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
+            )
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
+            )
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_variant(
+                bencher,
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
             )
         }
     }

--- a/crates/wordchipper-bench/benches/encoding_single.rs
+++ b/crates/wordchipper-bench/benches/encoding_single.rs
@@ -30,9 +30,12 @@ pub fn bench_wc(
     text: &str,
     model: OATokenizer,
     selector: SpanEncoderSelector,
+    accelerator: bool,
 ) {
     let encoder = encoder_builder::<u32>(model, selector)
+        .with_accelerated_lexers(accelerator)
         .with_parallel(false)
+        .with_concurrent(false)
         .build();
 
     bencher
@@ -69,12 +72,35 @@ mod english {
         use super::*;
 
         #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
+            );
+        }
+
+        #[divan::bench]
         fn cl100k(bencher: Bencher) {
             bench_wc(
                 bencher,
                 &english_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
             );
         }
 
@@ -85,6 +111,7 @@ mod english {
                 &english_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
             );
         }
     }
@@ -99,6 +126,7 @@ mod english {
                 &english_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
             );
         }
 
@@ -109,6 +137,29 @@ mod english {
                 &english_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
             );
         }
     }
@@ -123,6 +174,7 @@ mod english {
                 &english_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
             );
         }
 
@@ -133,6 +185,29 @@ mod english {
                 &english_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
             );
         }
     }
@@ -147,6 +222,7 @@ mod english {
                 &english_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
             );
         }
 
@@ -157,6 +233,29 @@ mod english {
                 &english_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &english_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
             );
         }
     }
@@ -211,6 +310,7 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
             );
         }
 
@@ -221,6 +321,29 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::BufferSweep,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::BufferSweep,
+                true,
             );
         }
     }
@@ -235,6 +358,7 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
             );
         }
 
@@ -245,6 +369,29 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::TailSweep,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::TailSweep,
+                true,
             );
         }
     }
@@ -260,6 +407,7 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
             );
         }
 
@@ -270,6 +418,29 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::MergeHeap,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::MergeHeap,
+                true,
             );
         }
     }
@@ -284,6 +455,7 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::Cl100kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
             );
         }
 
@@ -294,6 +466,29 @@ mod diverse {
                 &diverse_text(),
                 OATokenizer::O200kBase,
                 SpanEncoderSelector::PriorityMerge,
+                false,
+            );
+        }
+
+        #[divan::bench]
+        fn cl100k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::Cl100kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
+            );
+        }
+
+        #[divan::bench]
+        fn o200k_fast(bencher: Bencher) {
+            bench_wc(
+                bencher,
+                &diverse_text(),
+                OATokenizer::O200kBase,
+                SpanEncoderSelector::PriorityMerge,
+                true,
             );
         }
     }

--- a/crates/wordchipper-bench/benches/spanning.rs
+++ b/crates/wordchipper-bench/benches/spanning.rs
@@ -43,7 +43,9 @@ fn build_default_spanner(
     pattern: impl Into<wordchipper::support::regex::RegexPattern>
 ) -> Arc<dyn TextSpanner> {
     let config: TextSpanningConfig<u32> = TextSpanningConfig::from_pattern(pattern);
-    TextSpannerBuilder::new(config).with_parallel(false).build()
+    TextSpannerBuilder::new(config)
+        .with_concurrent(false)
+        .build()
 }
 
 mod english {

--- a/crates/wordchipper/src/spanning/span_lexers/regex_lexer_builder.rs
+++ b/crates/wordchipper/src/spanning/span_lexers/regex_lexer_builder.rs
@@ -29,14 +29,16 @@ impl SpanLexer for RegexWrapper {
 ///   `None` will use system/environment defaults.
 pub fn build_regex_lexer(
     pattern: RegexPattern,
+    accelerated: bool,
     concurrent: bool,
     max_pool: Option<NonZeroUsize>,
 ) -> Arc<dyn SpanLexer> {
+    let _ = accelerated;
     let _ = concurrent;
     let _ = max_pool;
 
     #[cfg(feature = "logos")]
-    {
+    if accelerated {
         use crate::spanning::span_lexers::logos::lookup_word_lexer;
         if let Some(lexer) = lookup_word_lexer(&pattern) {
             return lexer;


### PR DESCRIPTION
This pull request introduces support for accelerated lexers and updates benchmarking tests accordingly. Changes include:

- Added accelerated lexer configuration in `TextSpannerBuilder` and `TokenEncoderBuilder`.
- Implemented methods to enable, disable, or check accelerated lexer usage.
- Updated the `build_regex_lexer` function to utilize accelerated lexers when enabled.
- Extended benchmarks to include performance evaluations for accelerated lexer configurations in both `encoding_single` and `encoding_parallel`.


