### PR TITLE
Borrow &str instead of owned String in py encode()

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -56,9 +56,9 @@ impl Tokenizer {
     fn encode(
         &self,
         py: Python<'_>,
-        text: String,
+        text: &str,
     ) -> PyResult<Vec<u32>> {
-        py.detach(|| self.inner.try_encode(&text)).map_err(to_pyerr)
+        py.detach(|| self.inner.try_encode(text)).map_err(to_pyerr)
     }
 
     fn encode_batch(


### PR DESCRIPTION
## Summary
- Accept `&str` instead of `String` in the Python `encode()` binding, avoiding one heap allocation per call by borrowing directly from the Python string's internal UTF-8 buffer.

## Benchmarks

```
  batch/cl100k_base:
    tiktoken                                                     104.9 MB/s
    tokenizers                                                     5.5 MB/s
    wordchipper                                                  278.2 MB/s
    wordchipper_threadpool                                       187.2 MB/s

  batch/o200k_base:
    tiktoken                                                      76.1 MB/s
    tokenizers                                                     5.6 MB/s
    wordchipper                                                  286.2 MB/s
    wordchipper_threadpool                                       186.2 MB/s

  decode/diverse/cl100k_base:
    tiktoken                                                     236.5 MB/s
    tokenizers                                                    34.1 MB/s
    wordchipper                                                  248.2 MB/s

  decode/diverse/o200k_base:
    tiktoken                                                     263.6 MB/s
    tokenizers                                                    37.6 MB/s
    wordchipper                                                  280.7 MB/s

  decode/english/cl100k_base:
    tiktoken                                                     300.4 MB/s
    tokenizers                                                    39.9 MB/s
    wordchipper                                                  312.2 MB/s

  decode/english/o200k_base:
    tiktoken                                                     302.5 MB/s
    tokenizers                                                    40.3 MB/s
    wordchipper                                                  317.3 MB/s

  single/diverse/cl100k_base:
    tiktoken                                                      14.7 MB/s
    tokenizers                                                     5.1 MB/s
    wordchipper                                                   54.5 MB/s

  single/diverse/o200k_base:
    tiktoken                                                      10.5 MB/s
    tokenizers                                                     5.1 MB/s
    wordchipper                                                   35.7 MB/s

  single/english/cl100k_base:
    tiktoken                                                      15.1 MB/s
    tokenizers                                                     4.8 MB/s
    wordchipper                                                   84.6 MB/s

  single/english/o200k_base:
    tiktoken                                                      10.6 MB/s
    tokenizers                                                     4.8 MB/s
    wordchipper                                                   80.8 MB/s
```

## Test plan
- [x] `cargo check -p wordchipper-python` passes
- [x] `pytest benchmarks/` passes (no regression)