### PR TITLE
Parallelize CI into 5 concurrent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,24 @@ jobs:
           uv pip install maturin pytest
           maturin develop
           pytest tests/ -v
+
+  ci:
+    name: CI
+    if: always()
+    needs: [fmt, clippy, test, cross, python]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          results=(
+            "${{ needs.fmt.result }}"
+            "${{ needs.clippy.result }}"
+            "${{ needs.test.result }}"
+            "${{ needs.cross.result }}"
+            "${{ needs.python.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" ]]; then
+              echo "Job failed with result: $r"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
- Split single sequential CI job into 5 parallel jobs: **fmt**, **clippy**, **test**, **cross** (no_std), and **python**
- Wall-clock time drops from sum-of-all-steps to the slowest individual job
- Removed redundant manual cargo registry cache (already handled by `Swatinem/rust-cache`)
- Inlined rustup component/target installation flags

## Test plan
- [ ] Verify all 5 jobs pass on this PR
- [ ] Confirm jobs run in parallel (no `needs:` dependencies)