### PR TITLE
Add Makefile.toml for automation tasks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -53,12 +53,6 @@ description = "Check no_std build for thumbv7m-none-eabi"
 command = "cargo"
 args = ["check", "-p", "wordchipper", "--target", "thumbv7m-none-eabi", "--no-default-features"]
 
-[tasks.minimal-versions]
-description = "Verify minimum dependency versions resolve and tests pass"
-script = """
-cargo +nightly update -Z minimal-versions
-cargo test --workspace
-"""
 
 # ── convenience composites ────────────────────────────────────────────────────
 
@@ -74,18 +68,11 @@ dependencies = ["cross-wasm", "cross-thumb"]
 description = "All test variants (default, ahash, no_std)"
 dependencies = ["test", "test-ahash", "test-no-std"]
 
-[tasks.bindings]
-description = "All language binding tests"
-dependencies = ["wasm-bindings", "python-bindings"]
-
 [tasks.ci]
 description = "Full CI validation (mirrors GitHub Actions)"
 dependencies = [
     "check-format",
     "clippy",
-    "test",
-    "test-ahash",
-    "test-no-std",
-    "cross-wasm",
-    "cross-thumb",
+    "tests-all",
+    "cross",
 ]


### PR DESCRIPTION
This PR introduces a `Makefile.toml` file with predefined task configurations for build, testing, and CI automation. This simplifies common workflows and ensures consistency across developers.

### Changes
- Added `Makefile.toml` with tasks for:
  - Building the project
  - Running tests
  - Automation in CI pipelines
