### PR TITLE
Refactor `ListModels` command into `Models` subcommand.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p wchipper
       - run: cargo test --workspace
       - run: cargo test -p wordchipper --no-default-features --features client,fast-hash
       - run: cargo test -p wordchipper --no-default-features --tests
@@ -84,7 +85,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [fmt, clippy, test, cross, wasm, python]
+    needs: [ fmt, clippy, test, cross, wasm, python ]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/crates/wchipper/Cargo.toml
+++ b/crates/wchipper/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-wordchipper = { version = "0.8.0", path = "../wordchipper", features = ["default"] }
+wordchipper = { version = "0.8.0", path = "../wordchipper", features = ["client"] }
 wordchipper-training = { version = "0.8.0", path = "../wordchipper-training" }
 stderrlog = { workspace = true }
 log = { workspace = true }

--- a/crates/wchipper/src/commands/mod.rs
+++ b/crates/wchipper/src/commands/mod.rs
@@ -1,5 +1,5 @@
 mod cat;
-mod list_models;
+mod models;
 mod train;
 
 /// Subcommands for wchipper
@@ -8,8 +8,8 @@ pub enum Commands {
     /// Act as a streaming tokenizer.
     Cat(cat::CatArgs),
 
-    /// List available models.
-    ListModels(list_models::ListModelsArgs),
+    /// Models sub-menu.
+    Models(models::ModelsArgs),
 
     /// Train a new model.
     Train(train::TrainArgs),
@@ -20,7 +20,7 @@ impl Commands {
     pub fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Commands::Cat(cmd) => cmd.run(),
-            Commands::ListModels(cmd) => cmd.run(),
+            Commands::Models(cmd) => cmd.run(),
             Commands::Train(cmd) => cmd.run(),
         }
     }

--- a/crates/wchipper/src/commands/models/list_models.rs
+++ b/crates/wchipper/src/commands/models/list_models.rs
@@ -1,4 +1,3 @@
-/// Args for the model listing command.
 #[derive(clap::Args, Debug)]
 pub struct ListModelsArgs {}
 

--- a/crates/wchipper/src/commands/models/mod.rs
+++ b/crates/wchipper/src/commands/models/mod.rs
@@ -1,0 +1,27 @@
+use list_models::ListModelsArgs;
+
+mod list_models;
+
+/// Subcommands for the models command.
+#[derive(clap::Subcommand, Debug)]
+pub enum ModelsCommand {
+    /// List available models.
+    #[clap(visible_alias = "ls")]
+    List(ListModelsArgs),
+}
+
+/// Args for the model listing command.
+#[derive(clap::Args, Debug)]
+pub struct ModelsArgs {
+    #[clap(subcommand)]
+    pub command: ModelsCommand,
+}
+
+impl ModelsArgs {
+    /// Run the model listing command.
+    pub fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        match &self.command {
+            ModelsCommand::List(cmd) => cmd.run(),
+        }
+    }
+}

--- a/crates/wchipper/src/main.rs
+++ b/crates/wchipper/src/main.rs
@@ -10,6 +10,7 @@ use commands::Commands;
 
 /// Text tokenizer multi-tool.
 #[derive(clap::Parser, Debug)]
+#[command(name = "wchipper")]
 pub struct Args {
     /// Subcommand to run.
     #[clap(subcommand)]


### PR DESCRIPTION

- Renamed `ListModels` command to `Models` and added subcommand structure.
- Introduced `ModelsCommand` with support for extended functionality.
- Updated `Cargo.toml` to adjust `wordchipper` feature configuration.
- Minor workflow updates to include `cargo build` in CI.