### PR TITLE
Update READMEs with badges, crate links, and improved usage details

### DIFF
--- a/crates/wchipper/README.md
+++ b/crates/wchipper/README.md
@@ -1,13 +1,57 @@
 # wchipper
 
+[![Crates.io Version](https://img.shields.io/crates/v/wchipper)](https://crates.io/crates/wchipper)
+[![Documentation](https://img.shields.io/docsrs/wordchipper)](https://docs.rs/wordchipper/latest/wchipper/)
+[![Test Status](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml/badge.svg)](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml)
+
 A text LLM tokenizer command line multi-tool.
 
-Released as part of [wordchipper](https://crates.io/crates/wordchipper) suite.
+## Overview
 
-## list-models
+Part of the [wordchipper tokenizer suite](https://crates.io/crates/wordchipper).
+
+### Suite Crates
+
+This is the binary tokenizer multi-tool for the
+[wordchipper tokenizer suite](https://github.com/crutcher/wordchipper).
+
+The core additional user-facing crates are:
+
+* [wordchipper](https://crates.io/crates/wordchipper) - the core tokenizer library.
+* [wordchipper-training](https://crates.io/crates/wordchipper-training) - an extension crate for training tokenizers.
+
+## Installation
 
 ```terminaloutput
- % wchipper list-models                  
+% cargo install wchipper
+```
+
+## Usage
+
+`wchipper <COMMAND>`
+
+* `cat` - encode/decode text
+* `models <COMMAND>`
+    * `list`|`ls` - list available models
+* `train` - train a tokenizer
+
+### Usage: wchipper cat
+
+```terminaloutput
+% echo "abc def" | wchipper cat --encode --model=openai::gpt2
+39305 825 198
+
+% echo "39305 825 198" | cargo run --release -p wordchipper-cli -- \
+    cat --decode --model=openai::gpt2
+abc def
+```
+
+### Usage: wchipper models
+
+#### Usage: wchipper models list
+
+```terminaloutput
+ % wchipper models list                  
 "openai" - Pretrained vocabularies from OpenAI
   * "openai:gpt2"
     GPT-2 `gpt2` vocabulary
@@ -25,18 +69,7 @@ Released as part of [wordchipper](https://crates.io/crates/wordchipper) suite.
     GPT-5 `o200k_harmony` vocabulary
 ```
 
-## cat
-
-```terminaloutput
-% echo "abc def" | wchipper cat --encode --model=openai::gpt2
-39305 825 198
-
-% echo "39305 825 198" | cargo run --release -p wordchipper-cli -- \
-    cat --decode --model=openai::gpt2
-abc def
-```
-
-## train
+### Usage: wchipper train
 
 ```terminal
 % wchipper train --output=/tmp/tok.tokenizer \

--- a/crates/wordchipper-training/README.md
+++ b/crates/wordchipper-training/README.md
@@ -1,16 +1,37 @@
 # wordchipper-training
 
-See: [wordchipper](https://crates.io/crates/wordchipper)
+[![Crates.io Version](https://img.shields.io/crates/v/wordchipper-training)](https://crates.io/crates/wordchipper-training)
+[![Documentation](https://img.shields.io/docsrs/wordchipper-training)](https://docs.rs/wordchipper/latest/wordchipper-training/)
+[![Test Status](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml/badge.svg)](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/crutcher/wordchipper)
 
-This crate provides utilities for training WordChipper tokenizers and vocabularies.
+Part of the [wordchipper tokenizer suite](https://crates.io/crates/wordchipper).
+
+See: [wordchipper](https://crates.io/crates/wordchipper)
 
 ## Status: Working Prototype
 
 This crate is functional but has not received the same level of scrutiny as the rest of the project.
 
-## Training Demo
+## Overview
 
-See the training demo in [wordchipper-cli](../wchipper)
+This crate provides utilities for training WordChipper tokenizers and vocabularies.
+
+### Suite Crates
+
+This is the training implementation crate for the
+[wordchipper tokenizer suite](https://github.com/crutcher/wordchipper).
+
+The core additional user-facing crates are:
+
+* [wordchipper](https://crates.io/crates/wordchipper) - the core tokenizer library.
+* [wchipper](https://crates.io/crates/wchipper) - a multi-tool tokenizer binary; notably:
+    * `wchipper cat` - in-line encoder/decoder tool.
+    * `wchipper train` - tokenizer training tool.
+
+## Training Tool
+
+A pre-built training tool is shipped as part of the [`wchipper`](https://crates.io/crates/wchipper) tool.
 
 ## Training
 

--- a/crates/wordchipper/README.md
+++ b/crates/wordchipper/README.md
@@ -5,9 +5,7 @@
 [![Test Status](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml/badge.svg)](https://github.com/crutcher/wordchipper/actions/workflows/ci.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/crutcher/wordchipper)
 
-## Overview
-
-This is a high-performance rust BPE tokenizer trainer/encoder/decoder.
+## Status
 
 This is ready for alpha users, and is 2x the speed of `tiktoken-rs`
 for many current models.
@@ -15,6 +13,21 @@ for many current models.
 The productionization towards an LTR stable release can be
 tracked in the
 [Alpha Release Tracking Issue](https://github.com/crutcher/wordchipper/issues/2).
+
+## Overview
+
+This is a high-performance rust BPE tokenizer trainer/encoder/decoder.
+
+### Suite Crates
+
+This is the main crate for the [wordchipper](https://github.com/crutcher/wordchipper) project.
+
+The core additional user-facing crates are:
+
+* [wchipper](https://crates.io/crates/wchipper) - a multi-tool tokenizer binary; notably:
+    * `wchipper cat` - in-line encoder/decoder tool.
+    * `wchipper train` - tokenizer training tool.
+* [wordchipper-training](https://crates.io/crates/wordchipper-training) - an extension crate for training tokenizers.
 
 ## Encode/Decode Side-by-Side Benchmarks
 
@@ -79,73 +92,6 @@ fn example() -> wordchipper::errors::Result<(Arc<dyn TokenEncoder<u32>>, Arc<dyn
 
     Ok((encoder, decoder))
 }
-```
-
-## Training Overview
-
-* [Training Example](https://docs.rs/wordchipper/latest/wordchipper/training/index.html)
-
-This is a code snippet overview of training.
-
-Expect training to take ~1s/10MB of input; and to be slowed
-primarily by how well the stream logic of loading the training
-samples is parallelized.
-
-Note: currently, training has limited logging, and no progress reporting.
-
-A common training binary is probably a good idea; and much of the messiness
-of supporting many different training data sources could be hidden in
-the isolated deps of such a tool.
-
-Each shard is ~90MB parquet file.
-
-```terminaloutput
-$ time cargo run --release -p tokenizer_trainer -- --dataset-dir ~/Data/nanochat/dataset --shards 
-..8 --voc
-ab-size=65536 --time-encode-decode                                        
-   Compiling anyhow v1.0.100
-   Compiling wordchipper-disk-cache v0.2.2 (/Users/crutcher/git/wordchipper/crates/wordchipper-disk-cache)
-   Compiling wordchipper-data v0.0.0 (/Users/crutcher/git/wordchipper/crates/wordchipper-data)
-   Compiling wordchipper v0.2.2 (/Users/crutcher/git/wordchipper/crates/wordchipper)
-   Compiling tokenizer_trainer v0.0.0 (/Users/crutcher/git/wordchipper/examples/tokenizer_trainer)
-    Finished `release` profile [optimized] target(s) in 2.68s
-     Running `target/release/tokenizer_trainer --dataset-dir /Users/crutcher/Data/nanochat/dataset --shards ..8 --vocab-size=65536 --time-encode-decode`
-Loading Shards: [0, 1, 2, 3, 4, 5, 6, 7]
-...
-
-Training Tokenizer on shards: [0, 1, 2, 3, 4, 5, 6, 7]
-- shard: 0
-- shard: 1
-- shard: 2
-- shard: 3
-- shard: 4
-- shard: 5
-- shard: 6
-- shard: 7
-- train
-- training_duration: 106.70s
-- vocab_size: 65535
-
-Samples Summary:
-- count: 20480
-- avg size: 4741
-
-Timing Config:
-- batch size: 512
-
-Timing Encode:
-- batch avg: 18.276894ms
-- sample avg: 35.697µs
-- avg bps: 132.81 MB/s
-
-Observed Bytes/Token Stats:
-- total bytes: 97103222
-- total tokens: 24645141
-- sample byte/token: 3.94
-
-Timing Decode:
-- batch avg: 1.829894ms
-- sample avg: 3.574µs
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
- Added status badges (Crates.io, Docs.rs, and CI) to READMEs.
- Enhanced documentation with links to related crates in the `wordchipper` suite.
- Revised examples and command usage for `wchipper` and `wordchipper-training` for better clarity.
- Improved project overview sections for consistency across crates.