### PR TITLE
Tighten rustfmt settings for enhanced code formatting

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,4 +1,7 @@
-use pyo3::{prelude::*, pymodule};
+use pyo3::{
+    prelude::*,
+    pymodule,
+};
 
 pub(crate) mod wc {
     pub use wordchipper::{
@@ -6,7 +9,10 @@ pub(crate) mod wc {
         TokenizerOptions,
         disk_cache::WordchipperDiskCache,
         support::{
-            slices::{inner_slice_view, inner_str_view},
+            slices::{
+                inner_slice_view,
+                inner_str_view,
+            },
             strings::string_from_utf8_lossy,
         },
         vocab::io::save_base64_span_map_path,

--- a/bindings/python/src/support.rs
+++ b/bindings/python/src/support.rs
@@ -1,6 +1,9 @@
 use pyo3::{
     PyErr,
-    exceptions::{PyIOError, PyValueError},
+    exceptions::{
+        PyIOError,
+        PyValueError,
+    },
 };
 
 pub fn to_pyerr(err: wordchipper::WCError) -> PyErr {

--- a/bindings/python/src/tokenizer/tokenizer_impl.rs
+++ b/bindings/python/src/tokenizer/tokenizer_impl.rs
@@ -1,10 +1,22 @@
 use std::sync::Arc;
 
-use pyo3::{PyResult, Python, pyclass, pymethods};
-use wordchipper::{TokenDecoder, TokenEncoder, VocabIndex};
+use pyo3::{
+    PyResult,
+    Python,
+    pyclass,
+    pymethods,
+};
+use wordchipper::{
+    TokenDecoder,
+    TokenEncoder,
+    VocabIndex,
+};
 
 use super::TokenizerOptions;
-use crate::{support::to_pyerr, wc};
+use crate::{
+    support::to_pyerr,
+    wc,
+};
 
 #[pyclass]
 pub struct Tokenizer {

--- a/bindings/python/src/tokenizer/tokenizer_options.rs
+++ b/bindings/python/src/tokenizer/tokenizer_options.rs
@@ -1,4 +1,7 @@
-use pyo3::{pyclass, pymethods};
+use pyo3::{
+    pyclass,
+    pymethods,
+};
 
 use crate::wc;
 
@@ -57,7 +60,8 @@ impl TokenizerOptions {
 
     /// Gets the configured parallelism value.
     ///
-    /// Returns true if either encoder or decoder are configured for parallelism.
+    /// Returns true if either encoder or decoder are configured for
+    /// parallelism.
     ///
     /// Enabling parallelism will request threaded implementations.
     fn parallel(&self) -> bool {

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -4,10 +4,22 @@
 
 extern crate alloc;
 
-use alloc::{format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    format,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
 
-use base64::{Engine, prelude::BASE64_STANDARD};
-use js_sys::{Array, JsString, Uint32Array};
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD,
+};
+use js_sys::{
+    Array,
+    JsString,
+    Uint32Array,
+};
 use wasm_bindgen::prelude::*;
 use wordchipper::{
     TokenDecoder,
@@ -18,10 +30,16 @@ use wordchipper::{
     VocabIndex,
     pretrained::openai::OATokenizer,
     support::{
-        slices::{inner_slice_view, inner_str_view},
+        slices::{
+            inner_slice_view,
+            inner_str_view,
+        },
         strings::string_from_utf8_lossy,
     },
-    vocab::{SpanMapVocab, SpanTokenMap},
+    vocab::{
+        SpanMapVocab,
+        SpanTokenMap,
+    },
 };
 
 /// Parse tiktoken base64-encoded vocab data from raw bytes.
@@ -163,7 +181,8 @@ impl Tokenizer {
         }
     }
 
-    /// Look up the token ID for a given token string. Returns null if not found.
+    /// Look up the token ID for a given token string. Returns null if not
+    /// found.
     #[wasm_bindgen(js_name = "tokenToId")]
     pub fn token_to_id(
         &self,
@@ -175,7 +194,8 @@ impl Tokenizer {
         }
     }
 
-    /// Look up the token string for a given token ID. Returns null if not found.
+    /// Look up the token string for a given token ID. Returns null if not
+    /// found.
     #[wasm_bindgen(js_name = "idToToken")]
     pub fn id_to_token(
         &self,

--- a/bindings/wasm/tests/tokenizer.rs
+++ b/bindings/wasm/tests/tokenizer.rs
@@ -1,7 +1,14 @@
 //! WASM binding tests using `wasm-bindgen-test`.
 
-use base64::{Engine, prelude::BASE64_STANDARD};
-use js_sys::{Array, JsString, Uint32Array};
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD,
+};
+use js_sys::{
+    Array,
+    JsString,
+    Uint32Array,
+};
 use wasm_bindgen_test::*;
 use wordchipper_wasm::Tokenizer;
 

--- a/crates/wchipper/src/commands/cat_cmd.rs
+++ b/crates/wchipper/src/commands/cat_cmd.rs
@@ -1,15 +1,28 @@
 use std::{
-    io::{BufRead, Write},
+    io::{
+        BufRead,
+        Write,
+    },
     sync::Arc,
 };
 
-use wordchipper::{TokenDecoder, TokenEncoder, Tokenizer};
+use wordchipper::{
+    TokenDecoder,
+    TokenEncoder,
+    Tokenizer,
+};
 
 use crate::util::{
     disk_cache,
-    input_output::{InputArgs, OutputArgs},
+    input_output::{
+        InputArgs,
+        OutputArgs,
+    },
     model_selector::ModelSelectorArgs,
-    tokenizer_mode::{TokenizerMode, TokenizerModeArgs},
+    tokenizer_mode::{
+        TokenizerMode,
+        TokenizerModeArgs,
+    },
 };
 
 /// Args for the cat command.

--- a/crates/wchipper/src/commands/lexers/lexers_cmd.rs
+++ b/crates/wchipper/src/commands/lexers/lexers_cmd.rs
@@ -1,4 +1,7 @@
-use crate::commands::lexers::{lexers_list_cmd, lexers_stress_cmd};
+use crate::commands::lexers::{
+    lexers_list_cmd,
+    lexers_stress_cmd,
+};
 
 /// Subcommands for the lexers command.
 #[derive(clap::Subcommand, Debug)]

--- a/crates/wchipper/src/commands/lexers/lexers_stress_cmd.rs
+++ b/crates/wchipper/src/commands/lexers/lexers_stress_cmd.rs
@@ -1,17 +1,29 @@
 use std::{
-    cmp::{max, min},
+    cmp::{
+        max,
+        min,
+    },
     sync::Arc,
 };
 
 use rayon::prelude::*;
 use wordchipper::{
-    spanners::span_lexers::{SpanLexer, accelerators::get_regex_accelerator},
-    support::regex::{RegexPattern, RegexWrapper},
+    spanners::span_lexers::{
+        SpanLexer,
+        accelerators::get_regex_accelerator,
+    },
+    support::regex::{
+        RegexPattern,
+        RegexWrapper,
+    },
 };
 
 use crate::{
     commands::lexers::LexerSelectorArgs,
-    util::{input_batcher::BatchedInputArgs, logging::LogArgs},
+    util::{
+        input_batcher::BatchedInputArgs,
+        logging::LogArgs,
+    },
 };
 
 #[derive(clap::Args, Debug)]

--- a/crates/wchipper/src/commands/lexers/mod.rs
+++ b/crates/wchipper/src/commands/lexers/mod.rs
@@ -4,4 +4,7 @@ mod lexers_stress_cmd;
 
 pub use lexers_cmd::*;
 
-pub use crate::util::{lexer_inventory::*, lexer_selector::*};
+pub use crate::util::{
+    lexer_inventory::*,
+    lexer_selector::*,
+};

--- a/crates/wchipper/src/commands/train_cmd.rs
+++ b/crates/wchipper/src/commands/train_cmd.rs
@@ -1,11 +1,19 @@
 use std::sync::Arc;
 
-use wordchipper::{UnifiedTokenVocab, VocabIndex, vocab::io::write_base64_span_map};
+use wordchipper::{
+    UnifiedTokenVocab,
+    VocabIndex,
+    vocab::io::write_base64_span_map,
+};
 use wordchipper_training::BPETRainerOptions;
 
 use crate::{
     commands::lexers::LexerSelectorArgs,
-    util::{input_batcher::BatchedInputArgs, input_output::OutputArgs, logging::LogArgs},
+    util::{
+        input_batcher::BatchedInputArgs,
+        input_output::OutputArgs,
+        logging::LogArgs,
+    },
 };
 
 /// File formats for the train command.

--- a/crates/wchipper/src/util/disk_cache.rs
+++ b/crates/wchipper/src/util/disk_cache.rs
@@ -1,4 +1,7 @@
-use wordchipper::disk_cache::{WordchipperDiskCache, WordchipperDiskCacheOptions};
+use wordchipper::disk_cache::{
+    WordchipperDiskCache,
+    WordchipperDiskCacheOptions,
+};
 
 /// Disk cache argument group.
 #[derive(clap::Args, Debug)]

--- a/crates/wchipper/src/util/input_batcher.rs
+++ b/crates/wchipper/src/util/input_batcher.rs
@@ -1,6 +1,12 @@
-use std::io::{BufRead, BufReader};
+use std::io::{
+    BufRead,
+    BufReader,
+};
 
-use arrow::array::{Array, StringArray};
+use arrow::array::{
+    Array,
+    StringArray,
+};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 use crate::commands::train_cmd::FileFormat;

--- a/crates/wchipper/src/util/input_output.rs
+++ b/crates/wchipper/src/util/input_output.rs
@@ -1,6 +1,10 @@
 use std::{
     fs::File,
-    io::{BufRead, BufReader, BufWriter},
+    io::{
+        BufRead,
+        BufReader,
+        BufWriter,
+    },
 };
 
 fn squash_standard_io(path: &Option<String>) -> Option<String> {

--- a/crates/wchipper/src/util/lexer_inventory.rs
+++ b/crates/wchipper/src/util/lexer_inventory.rs
@@ -1,5 +1,9 @@
 use wordchipper::{
-    pretrained::openai::{OA_CL100K_BASE_PATTERN, OA_GPT2_PATTERN, OA_O200K_BASE_PATTERN},
+    pretrained::openai::{
+        OA_CL100K_BASE_PATTERN,
+        OA_GPT2_PATTERN,
+        OA_O200K_BASE_PATTERN,
+    },
     spanners::span_lexers::accelerators::get_regex_accelerator,
 };
 

--- a/crates/wchipper/src/util/model_selector.rs
+++ b/crates/wchipper/src/util/model_selector.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use wordchipper::{Tokenizer, UnifiedTokenVocab, disk_cache::WordchipperDiskCache};
+use wordchipper::{
+    Tokenizer,
+    UnifiedTokenVocab,
+    disk_cache::WordchipperDiskCache,
+};
 
 /// Model selector arg group.
 #[derive(clap::Args, Debug)]

--- a/crates/wordchipper-disk-cache/src/disk_cache.rs
+++ b/crates/wordchipper-disk-cache/src/disk_cache.rs
@@ -2,12 +2,21 @@
 
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 
-use downloader::{Download, Downloader};
+use downloader::{
+    Download,
+    Downloader,
+};
 
-use crate::{WORDCHIPPER_CACHE_CONFIG, path_utils};
+use crate::{
+    WORDCHIPPER_CACHE_CONFIG,
+    path_utils,
+};
 
 /// Options for [`WordchipperDiskCache`].
 #[derive(Clone, Default, Debug)]
@@ -54,8 +63,8 @@ impl WordchipperDiskCacheOptions {
 /// Disk cache for downloaded files.
 ///
 /// Leverages [`Downloader`] for downloading files,
-/// and [`PathResolver`](`crate::PathResolver`) for resolving cache and data paths
-/// appropriate for a user/system combo, and any environment overrides.
+/// and [`PathResolver`](`crate::PathResolver`) for resolving cache and data
+/// paths appropriate for a user/system combo, and any environment overrides.
 pub struct WordchipperDiskCache {
     /// Cache directory.
     cache_dir: PathBuf,
@@ -131,30 +140,35 @@ impl WordchipperDiskCache {
         path_utils::extend_path(&self.cache_dir, context, file)
     }
 
-    /// Loads a cached file from a specified path or downloads it if it does not exist.
+    /// Loads a cached file from a specified path or downloads it if it does not
+    /// exist.
     ///
     /// # Arguments
-    /// * `context`: A slice of `C` containing path-related context used in determining the
-    ///   cache location. These paths are combined to build the cached file's location.
-    /// * `urls`: A slice of string references specifying the URLs to download the file from
-    ///   if it is not already cached.
-    /// * `download`: A boolean flag indicating whether to attempt downloading the file
-    ///   from the provided URLs if it does not already exist in the cache.
+    /// * `context`: A slice of `C` containing path-related context used in
+    ///   determining the cache location. These paths are combined to build the
+    ///   cached file's location.
+    /// * `urls`: A slice of string references specifying the URLs to download
+    ///   the file from if it is not already cached.
+    /// * `download`: A boolean flag indicating whether to attempt downloading
+    ///   the file from the provided URLs if it does not already exist in the
+    ///   cache.
     ///
     /// # Returns
-    /// * Returns a [`PathBuf`] pointing to the cached file if it exists or is successfully downloaded.
-    /// * Returns an error if the file is not found in the cache and downloading is not allowed
-    ///   or fails.
+    /// * Returns a [`PathBuf`] pointing to the cached file if it exists or is
+    ///   successfully downloaded.
+    /// * Returns an error if the file is not found in the cache and downloading
+    ///   is not allowed or fails.
     ///
     /// # Errors
-    /// * Returns an error if the cached file does not exist and `download` is `false`.
+    /// * Returns an error if the cached file does not exist and `download` is
+    ///   `false`.
     /// * Returns an error if the downloading process fails.
     pub fn load_cached_path<C, S>(
         &mut self,
         context: &[C],
         urls: &[S],
         download: bool,
-        /* TODO: hash: Option<&str>, */
+        // TODO: hash: Option<&str>,
     ) -> Result<PathBuf, Box<dyn std::error::Error>>
     where
         C: AsRef<Path>,
@@ -204,7 +218,10 @@ impl WordchipperDiskCache {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::PathBuf};
+    use std::{
+        env,
+        path::PathBuf,
+    };
 
     use serial_test::serial;
 
@@ -212,7 +229,10 @@ mod tests {
         WORDCHIPPER_CACHE_CONFIG,
         WORDCHIPPER_CACHE_DIR,
         WORDCHIPPER_DATA_DIR,
-        disk_cache::{WordchipperDiskCache, WordchipperDiskCacheOptions},
+        disk_cache::{
+            WordchipperDiskCache,
+            WordchipperDiskCacheOptions,
+        },
     };
 
     #[test]

--- a/crates/wordchipper-disk-cache/src/lib.rs
+++ b/crates/wordchipper-disk-cache/src/lib.rs
@@ -6,7 +6,9 @@ mod path_resolver;
 mod path_utils;
 
 #[doc(inline)]
-pub use disk_cache::{WordchipperDiskCache, WordchipperDiskCacheOptions};
+pub use disk_cache::WordchipperDiskCache;
+#[doc(inline)]
+pub use disk_cache::WordchipperDiskCacheOptions;
 #[doc(inline)]
 pub use path_resolver::PathResolver;
 #[doc(inline)]

--- a/crates/wordchipper-disk-cache/src/path_resolver.rs
+++ b/crates/wordchipper-disk-cache/src/path_resolver.rs
@@ -4,7 +4,10 @@
 
 use std::{
     env,
-    path::{Path, PathBuf},
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 
 use directories_next::ProjectDirs;

--- a/crates/wordchipper-disk-cache/src/path_utils.rs
+++ b/crates/wordchipper-disk-cache/src/path_utils.rs
@@ -1,6 +1,9 @@
 //! # Path Utilities
 
-use std::path::{Path, PathBuf};
+use std::path::{
+    Path,
+    PathBuf,
+};
 
 /// Extend a path with a context and filename.
 ///

--- a/crates/wordchipper-training/src/bpe_trainer.rs
+++ b/crates/wordchipper-training/src/bpe_trainer.rs
@@ -4,7 +4,10 @@ use core::cmp::Ordering;
 
 use compact_str::CompactString;
 use dary_heap::OctonaryHeap;
-use num_traits::{One, Zero};
+use num_traits::{
+    One,
+    Zero,
+};
 use wordchipper::{
     Pair,
     TokenType,
@@ -19,13 +22,22 @@ use wordchipper::{
         ByteMapVocab,
         PairMapVocab,
         PairTokenMap,
-        utility::validators::{U8_SIZE, expect_vocab_size},
+        utility::validators::{
+            U8_SIZE,
+            expect_vocab_size,
+        },
     },
 };
 
 use crate::{
     CountType,
-    utility::{PairIndexMap, PairSpanIndex, TextSpanCounter, TextSpanCounterOptions, TokenSpanBuf},
+    utility::{
+        PairIndexMap,
+        PairSpanIndex,
+        TextSpanCounter,
+        TextSpanCounterOptions,
+        TokenSpanBuf,
+    },
 };
 
 /// Options for [`BPETrainer`].
@@ -62,7 +74,8 @@ impl BPETRainerOptions {
     /// Sets the vocab size.
     ///
     /// ## Arguments
-    /// * `vocab_size` - The desired vocabulary size; must be >= 256 (the size of the u8 space).
+    /// * `vocab_size` - The desired vocabulary size; must be >= 256 (the size
+    ///   of the u8 space).
     ///
     /// ## Returns
     /// The updated `BinaryPairVocabTrainerOptions` instance.
@@ -215,7 +228,8 @@ impl BPETrainer {
     ///
     /// The resulting vocab will contain:
     /// * the trainer's word split pattern,
-    /// * a ``{(T, T) -> T}`` pair map vocab with the learned binary pair merges,
+    /// * a ``{(T, T) -> T}`` pair map vocab with the learned binary pair
+    ///   merges,
     /// * a ``{Vec<u8> -> T}`` word map that is empty.
     ///
     /// ## Arguments
@@ -377,7 +391,8 @@ impl BPETrainer {
     ///
     /// The resulting vocab will contain:
     /// * the trainer's word split pattern,
-    /// * a ``{(T, T) -> T}`` pair map vocab with the learned binary pair merges,
+    /// * a ``{(T, T) -> T}`` pair map vocab with the learned binary pair
+    ///   merges,
     /// * a ``{Vec<u8> -> T}`` word map that is empty.
     ///
     /// ## Arguments
@@ -412,7 +427,10 @@ mod tests {
         vocab::ByteMapVocab,
     };
 
-    use crate::{BPETRainerOptions, bpe_trainer::MergeJob};
+    use crate::{
+        BPETRainerOptions,
+        bpe_trainer::MergeJob,
+    };
 
     #[test]
     fn test_tokenizer_options() {

--- a/crates/wordchipper-training/src/lib.rs
+++ b/crates/wordchipper-training/src/lib.rs
@@ -3,7 +3,8 @@
 //! Support for training token vocabularies.
 //!
 //! Training requires:
-//! * [`wordchipper::vocab::ByteMapVocab`] - a choice of ``{ u8 -> T }` byte mappings.
+//! * [`wordchipper::vocab::ByteMapVocab`] - a choice of ``{ u8 -> T }` byte
+//!   mappings.
 //!   * The default is ``T::from(u8)``.
 //! * [`wordchipper::spanners::TextSpanningConfig`] - a text splitting config.
 //!   * This can be built from just a regex pattern.
@@ -23,7 +24,8 @@
 //! of supporting many different training data sources could be hidden in
 //! the isolated deps of such a tool.
 //!
-//! Consider the following, to train a tokenizer and export it a "*.tiktoken" file.
+//! Consider the following, to train a tokenizer and export it a "*.tiktoken"
+//! file.
 //!
 //! - The iterator stream for samples may be quite large.
 //! - Training a `nanochat` equivalent tokenizer takes ~80 CPU minutes.
@@ -36,9 +38,15 @@
 //!     TokenizerOptions,
 //!     UnifiedTokenVocab,
 //!     pretrained::openai::OA_CL100K_BASE_PATTERN,
-//!     vocab::{ByteMapVocab, io::save_base64_span_map_path},
+//!     vocab::{
+//!         ByteMapVocab,
+//!         io::save_base64_span_map_path,
+//!     },
 //! };
-//! use wordchipper_training::{BPETRainerOptions, BPETrainer};
+//! use wordchipper_training::{
+//!     BPETRainerOptions,
+//!     BPETrainer,
+//! };
 //!
 //! fn example<I, S>(
 //!     vocab_size: usize,
@@ -54,7 +62,8 @@
 //!     // See [`wordchipper::TokenType`].
 //!     type T = u32;
 //!
-//!     let mut trainer = BPETRainerOptions::new(OA_CL100K_BASE_PATTERN, vocab_size).init();
+//!     let mut trainer =
+//!         BPETRainerOptions::new(OA_CL100K_BASE_PATTERN, vocab_size).init();
 //!
 //!     for batch in batches {
 //!         // The trainer has no parallelism.
@@ -90,6 +99,10 @@ mod bpe_trainer;
 mod training_types;
 
 #[doc(inline)]
-pub use bpe_trainer::{BPETRainerOptions, BPETrainer};
+pub use bpe_trainer::BPETRainerOptions;
 #[doc(inline)]
-pub use training_types::{CountType, StringChunkType};
+pub use bpe_trainer::BPETrainer;
+#[doc(inline)]
+pub use training_types::CountType;
+#[doc(inline)]
+pub use training_types::StringChunkType;

--- a/crates/wordchipper-training/src/training_types.rs
+++ b/crates/wordchipper-training/src/training_types.rs
@@ -1,11 +1,21 @@
 //! # Training Types
 use core::{
-    fmt::{Debug, Display},
+    fmt::{
+        Debug,
+        Display,
+    },
     hash::Hash,
-    ops::{AddAssign, SubAssign},
+    ops::{
+        AddAssign,
+        SubAssign,
+    },
 };
 
-use num_traits::{FromPrimitive, PrimInt, ToPrimitive};
+use num_traits::{
+    FromPrimitive,
+    PrimInt,
+    ToPrimitive,
+};
 
 /// A type that can be used as a string key.
 pub trait StringChunkType:

--- a/crates/wordchipper-training/src/utility/mod.rs
+++ b/crates/wordchipper-training/src/utility/mod.rs
@@ -5,8 +5,14 @@ mod text_span_counter;
 mod token_span_buffer;
 
 #[doc(inline)]
-pub use pair_span_index::{PairCountMap, PairIndexMap, PairSpanIndex};
+pub use pair_span_index::PairCountMap;
 #[doc(inline)]
-pub use text_span_counter::{TextSpanCounter, TextSpanCounterOptions};
+pub use pair_span_index::PairIndexMap;
+#[doc(inline)]
+pub use pair_span_index::PairSpanIndex;
+#[doc(inline)]
+pub use text_span_counter::TextSpanCounter;
+#[doc(inline)]
+pub use text_span_counter::TextSpanCounterOptions;
 #[doc(inline)]
 pub use token_span_buffer::TokenSpanBuf;

--- a/crates/wordchipper-training/src/utility/pair_span_index.rs
+++ b/crates/wordchipper-training/src/utility/pair_span_index.rs
@@ -1,8 +1,17 @@
 //! # `PairIndex` Builder
 
-use wordchipper::{Pair, TokenType, WCHashMap, WCHashSet, hash_map_with_capacity};
+use wordchipper::{
+    Pair,
+    TokenType,
+    WCHashMap,
+    WCHashSet,
+    hash_map_with_capacity,
+};
 
-use crate::{CountType, utility::TokenSpanBuf};
+use crate::{
+    CountType,
+    utility::TokenSpanBuf,
+};
 
 /// A map from [`Pair`] to its occurrence count.
 pub type PairCountMap<T, C> = WCHashMap<Pair<T>, C>;
@@ -10,7 +19,8 @@ pub type PairCountMap<T, C> = WCHashMap<Pair<T>, C>;
 /// A map from [`Pair`] to indices over ``words``.
 pub type PairIndexMap<T> = WCHashMap<Pair<T>, WCHashSet<usize>>;
 
-/// An index of ``(T, T)`` pair information relative to a ``&[TokenSpanBuf<T>]``.
+/// An index of ``(T, T)`` pair information relative to a
+/// ``&[TokenSpanBuf<T>]``.
 #[derive(Debug, Clone)]
 pub struct PairSpanIndex<T: TokenType, C: CountType> {
     /// A map from [`Pair`] to its occurrence count.
@@ -23,7 +33,8 @@ pub struct PairSpanIndex<T: TokenType, C: CountType> {
 }
 
 impl<T: TokenType, C: CountType> PairSpanIndex<T, C> {
-    /// Build a [`PairSpanIndex`] from a slice of [`TokenSpanBuf`]s, using a count table.
+    /// Build a [`PairSpanIndex`] from a slice of [`TokenSpanBuf`]s, using a
+    /// count table.
     ///
     /// # Arguments
     /// * `spans` - a sequence of text spans; assumed to be unique.

--- a/crates/wordchipper-training/src/utility/text_span_counter.rs
+++ b/crates/wordchipper-training/src/utility/text_span_counter.rs
@@ -10,7 +10,11 @@ use wordchipper::{
     vocab::ByteMapVocab,
 };
 
-use crate::{CountType, StringChunkType, utility::TokenSpanBuf};
+use crate::{
+    CountType,
+    StringChunkType,
+    utility::TokenSpanBuf,
+};
 
 /// Expected average word length in characters.
 pub const EXPECTED_WORD_LENGTH: usize = 5;
@@ -123,7 +127,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use wordchipper::{WCHashMap, hash_map_new, support::regex::RegexPattern};
+    use wordchipper::{
+        WCHashMap,
+        hash_map_new,
+        support::regex::RegexPattern,
+    };
 
     use super::*;
 

--- a/crates/wordchipper-training/src/utility/token_span_buffer.rs
+++ b/crates/wordchipper-training/src/utility/token_span_buffer.rs
@@ -2,7 +2,11 @@
 
 use core::hash::Hash;
 
-use wordchipper::{Pair, TokenType, vocab::ByteMapVocab};
+use wordchipper::{
+    Pair,
+    TokenType,
+    vocab::ByteMapVocab,
+};
 
 /// A mutable span of tokens (a chunk or "word").
 ///
@@ -53,7 +57,8 @@ impl<T: TokenType> TokenSpanBuf<T> {
     /// Create a new span buf from a string slice.
     ///
     /// # Arguments
-    /// * `text` - the text to turn into UTF-8 bytes, and translate to byte-level tokens.
+    /// * `text` - the text to turn into UTF-8 bytes, and translate to
+    ///   byte-level tokens.
     /// * `byte_vocab` - the translation for the byte tokens.
     pub fn from_string<S: AsRef<str>>(
         text: S,
@@ -92,10 +97,11 @@ impl<T: TokenType> TokenSpanBuf<T> {
     /// # Arguments
     /// * `pair` - the pair to merge.
     /// * `replacement` - the token to replace `pair` with.
-    /// * `on_merge` - a callback function to invoke for each incremental pair delta.
-    ///   The function is called with:
+    /// * `on_merge` - a callback function to invoke for each incremental pair
+    ///   delta. The function is called with:
     ///   - `pair` - the pair that was merged.
-    ///   - `delta` - the pair count delta: `+1` for an added pair, `-1` for a removed pair.
+    ///   - `delta` - the pair count delta: `+1` for an added pair, `-1` for a
+    ///     removed pair.
     pub fn merge_pair_cb<F>(
         &mut self,
         pair: Pair<T>,

--- a/crates/wordchipper/src/decoders/decode_results.rs
+++ b/crates/wordchipper/src/decoders/decode_results.rs
@@ -2,7 +2,10 @@
 
 use core::fmt::Debug;
 
-use crate::{WCResult, alloc::vec::Vec};
+use crate::{
+    WCResult,
+    alloc::vec::Vec,
+};
 
 /// The result of decoding tokens into bytes.
 #[derive(Debug)]
@@ -54,7 +57,8 @@ where
         Self { value, remaining }
     }
 
-    /// Try to unwrap the result, returning an error if the decoding is incomplete.
+    /// Try to unwrap the result, returning an error if the decoding is
+    /// incomplete.
     pub fn try_result(self) -> WCResult<V> {
         if let Some(remaining) = self.remaining
             && remaining > 0
@@ -123,7 +127,8 @@ where
         self.results.iter().all(|r| r.is_complete())
     }
 
-    /// Try to unwrap the results, returning an error if any decoding is incomplete.
+    /// Try to unwrap the results, returning an error if any decoding is
+    /// incomplete.
     pub fn try_results(self) -> WCResult<Vec<V>> {
         self.results.into_iter().map(|r| r.try_result()).collect()
     }
@@ -151,7 +156,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alloc::{string::ToString, vec};
+    use crate::alloc::{
+        string::ToString,
+        vec,
+    };
 
     #[test]
     fn test_decode_result_new() {

--- a/crates/wordchipper/src/decoders/mod.rs
+++ b/crates/wordchipper/src/decoders/mod.rs
@@ -5,7 +5,12 @@
 //! ```rust,no_run
 //! use std::sync::Arc;
 //!
-//! use wordchipper::{TokenDecoder, TokenDecoderOptions, TokenType, UnifiedTokenVocab};
+//! use wordchipper::{
+//!     TokenDecoder,
+//!     TokenDecoderOptions,
+//!     TokenType,
+//!     UnifiedTokenVocab,
+//! };
 //!
 //! fn example<T: TokenType>(
 //!     vocab: Arc<UnifiedTokenVocab<T>>,

--- a/crates/wordchipper/src/decoders/slab_index_decoder.rs
+++ b/crates/wordchipper/src/decoders/slab_index_decoder.rs
@@ -5,9 +5,20 @@ use core::marker::PhantomData;
 use crate::{
     TokenType,
     WCResult,
-    alloc::{sync::Arc, vec, vec::Vec},
-    decoders::{DecodeResult, TokenDecoder},
-    vocab::{DEFAULT_BYTE_PER_TOKEN_RATIO, TokenSpanMap, UnifiedTokenVocab},
+    alloc::{
+        sync::Arc,
+        vec,
+        vec::Vec,
+    },
+    decoders::{
+        DecodeResult,
+        TokenDecoder,
+    },
+    vocab::{
+        DEFAULT_BYTE_PER_TOKEN_RATIO,
+        TokenSpanMap,
+        UnifiedTokenVocab,
+    },
 };
 
 /// A [`TokenDecoder<T>`] which keeps a dense array index into a shared slab.
@@ -32,7 +43,8 @@ impl<T: TokenType> SlabIndexDecoder<T> {
     /// Build a [`SlabIndexDecoder`] from this [`UnifiedTokenVocab`].
     ///
     /// ## Arguments
-    /// * `unified_vocab` - The unified token vocabulary to build the decoder from.
+    /// * `unified_vocab` - The unified token vocabulary to build the decoder
+    ///   from.
     pub fn from_vocab(vocab: Arc<UnifiedTokenVocab<T>>) -> Self {
         Self::new(vocab.unified_dictionary())
     }
@@ -73,7 +85,8 @@ impl<T: TokenType> SlabIndexDecoder<T> {
 
     /// Sets the expected bytes per token.
     ///
-    /// This is used to bias the capacity of the output buffer in `try_decode_to_bytes`.
+    /// This is used to bias the capacity of the output buffer in
+    /// `try_decode_to_bytes`.
     pub fn with_expected_bytes_per_token(
         mut self,
         expected: f32,
@@ -140,7 +153,10 @@ mod tests {
         spanners::TextSpanningConfig,
         vocab::{
             UnifiedTokenVocab,
-            utility::testing::{build_test_shift_byte_vocab, build_test_vocab},
+            utility::testing::{
+                build_test_shift_byte_vocab,
+                build_test_vocab,
+            },
         },
     };
 

--- a/crates/wordchipper/src/decoders/token_decoder.rs
+++ b/crates/wordchipper/src/decoders/token_decoder.rs
@@ -3,8 +3,14 @@
 use crate::{
     TokenType,
     WCResult,
-    alloc::{string::String, vec::Vec},
-    decoders::{BatchDecodeResult, DecodeResult},
+    alloc::{
+        string::String,
+        vec::Vec,
+    },
+    decoders::{
+        BatchDecodeResult,
+        DecodeResult,
+    },
     support::strings::string_from_utf8_lossy,
 };
 
@@ -91,7 +97,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        alloc::{string::ToString, vec},
+        alloc::{
+            string::ToString,
+            vec,
+        },
         decoders::utility::ByteDecoder,
     };
 

--- a/crates/wordchipper/src/decoders/token_dict_decoder.rs
+++ b/crates/wordchipper/src/decoders/token_dict_decoder.rs
@@ -3,9 +3,19 @@
 use crate::{
     TokenType,
     WCResult,
-    alloc::{sync::Arc, vec::Vec},
-    decoders::{DecodeResult, TokenDecoder},
-    vocab::{DEFAULT_BYTE_PER_TOKEN_RATIO, TokenSpanMap, UnifiedTokenVocab},
+    alloc::{
+        sync::Arc,
+        vec::Vec,
+    },
+    decoders::{
+        DecodeResult,
+        TokenDecoder,
+    },
+    vocab::{
+        DEFAULT_BYTE_PER_TOKEN_RATIO,
+        TokenSpanMap,
+        UnifiedTokenVocab,
+    },
 };
 
 /// A [`TokenDecoder<T>`] over a unified `{ T -> Vec<u8> }` dictionary.
@@ -31,7 +41,8 @@ impl<T: TokenType> TokenDictDecoder<T> {
     /// Build a [`TokenDictDecoder`] from this [`UnifiedTokenVocab`].
     ///
     /// ## Arguments
-    /// * `unified_vocab` - The unified token vocabulary to build the decoder from.
+    /// * `unified_vocab` - The unified token vocabulary to build the decoder
+    ///   from.
     pub fn from_vocab(vocab: Arc<UnifiedTokenVocab<T>>) -> Self {
         Self::new(vocab.unified_dictionary())
     }
@@ -54,7 +65,8 @@ impl<T: TokenType> TokenDictDecoder<T> {
 
     /// Sets the expected bytes per token.
     ///
-    /// This is used to bias the capacity of the output buffer in `try_decode_to_bytes`.
+    /// This is used to bias the capacity of the output buffer in
+    /// `try_decode_to_bytes`.
     pub fn with_expected_bytes_per_token(
         mut self,
         expected: f32,
@@ -117,7 +129,10 @@ mod tests {
         spanners::TextSpanningConfig,
         vocab::{
             UnifiedTokenVocab,
-            utility::testing::{build_test_shift_byte_vocab, build_test_vocab},
+            utility::testing::{
+                build_test_shift_byte_vocab,
+                build_test_vocab,
+            },
         },
     };
 

--- a/crates/wordchipper/src/decoders/utility/byte_decoder.rs
+++ b/crates/wordchipper/src/decoders/utility/byte_decoder.rs
@@ -6,8 +6,14 @@ use crate::{
     TokenType,
     WCResult,
     alloc::vec::Vec,
-    decoders::{DecodeResult, TokenDecoder},
-    vocab::{ByteMapVocab, DEFAULT_BYTE_PER_TOKEN_RATIO},
+    decoders::{
+        DecodeResult,
+        TokenDecoder,
+    },
+    vocab::{
+        ByteMapVocab,
+        DEFAULT_BYTE_PER_TOKEN_RATIO,
+    },
 };
 
 /// A [`ByteMapVocab`] based [`TokenDecoder`].
@@ -67,7 +73,10 @@ impl<T: TokenType> TokenDecoder<T> for ByteDecoder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{alloc::vec, vocab::ByteMapVocab};
+    use crate::{
+        alloc::vec,
+        vocab::ByteMapVocab,
+    };
 
     #[test]
     fn test_decode_context() {

--- a/crates/wordchipper/src/decoders/utility/pair_decoder.rs
+++ b/crates/wordchipper/src/decoders/utility/pair_decoder.rs
@@ -3,9 +3,20 @@
 use crate::{
     TokenType,
     WCResult,
-    alloc::{vec, vec::Vec},
-    decoders::{DecodeResult, TokenDecoder},
-    vocab::{ByteMapVocab, DEFAULT_BYTE_PER_TOKEN_RATIO, PairMapVocab, TokenPairMap},
+    alloc::{
+        vec,
+        vec::Vec,
+    },
+    decoders::{
+        DecodeResult,
+        TokenDecoder,
+    },
+    vocab::{
+        ByteMapVocab,
+        DEFAULT_BYTE_PER_TOKEN_RATIO,
+        PairMapVocab,
+        TokenPairMap,
+    },
 };
 
 /// A stack-based pair map `{T -> (T, T) }` incremental stack [`TokenDecoder`].
@@ -115,7 +126,10 @@ mod tests {
         spanners::TextSpanningConfig,
         vocab::{
             UnifiedTokenVocab,
-            utility::testing::{build_test_shift_byte_vocab, build_test_vocab},
+            utility::testing::{
+                build_test_shift_byte_vocab,
+                build_test_vocab,
+            },
         },
     };
 

--- a/crates/wordchipper/src/decoders/utility/testing.rs
+++ b/crates/wordchipper/src/decoders/utility/testing.rs
@@ -3,10 +3,20 @@
 use crate::{
     TokenEncoderOptions,
     TokenType,
-    alloc::{sync::Arc, vec, vec::Vec},
+    alloc::{
+        sync::Arc,
+        vec,
+        vec::Vec,
+    },
     decoders::TokenDecoder,
-    support::{strings::string_from_utf8_lossy, traits::static_is_send_sync_check},
-    vocab::{UnifiedTokenVocab, VocabIndex},
+    support::{
+        strings::string_from_utf8_lossy,
+        traits::static_is_send_sync_check,
+    },
+    vocab::{
+        UnifiedTokenVocab,
+        VocabIndex,
+    },
 };
 
 /// Common Unittest for TokenDecoder implementations.

--- a/crates/wordchipper/src/encoders/encoder_options.rs
+++ b/crates/wordchipper/src/encoders/encoder_options.rs
@@ -7,7 +7,10 @@ use crate::{
     TokenType,
     UnifiedTokenVocab,
     alloc::sync::Arc,
-    encoders::token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+    encoders::token_span_encoder::{
+        SpanEncoderSelector,
+        TokenSpanEncoder,
+    },
     spanners::TextSpannerBuilder,
 };
 

--- a/crates/wordchipper/src/encoders/mod.rs
+++ b/crates/wordchipper/src/encoders/mod.rs
@@ -5,7 +5,12 @@
 //! ```rust,no_run
 //! use std::sync::Arc;
 //!
-//! use wordchipper::{TokenEncoder, TokenEncoderOptions, TokenType, UnifiedTokenVocab};
+//! use wordchipper::{
+//!     TokenEncoder,
+//!     TokenEncoderOptions,
+//!     TokenType,
+//!     UnifiedTokenVocab,
+//! };
 //!
 //! fn example<T: TokenType>(
 //!     vocab: Arc<UnifiedTokenVocab<T>>,

--- a/crates/wordchipper/src/encoders/testing.rs
+++ b/crates/wordchipper/src/encoders/testing.rs
@@ -2,16 +2,30 @@
 
 use crate::{
     TokenType,
-    alloc::{string::String, sync::Arc, vec, vec::Vec},
-    decoders::{TokenDecoder, TokenDictDecoder},
+    alloc::{
+        string::String,
+        sync::Arc,
+        vec,
+        vec::Vec,
+    },
+    decoders::{
+        TokenDecoder,
+        TokenDictDecoder,
+    },
     encoders::TokenEncoder,
     pretrained::openai::OA_CL100K_BASE_PATTERN,
     spanners::TextSpanningConfig,
-    support::{slices::inner_slice_view, traits::static_is_send_sync_check},
+    support::{
+        slices::inner_slice_view,
+        traits::static_is_send_sync_check,
+    },
     vocab::{
         UnifiedTokenVocab,
         VocabIndex,
-        utility::testing::{build_test_shift_byte_vocab, build_test_vocab},
+        utility::testing::{
+            build_test_shift_byte_vocab,
+            build_test_vocab,
+        },
     },
 };
 

--- a/crates/wordchipper/src/encoders/token_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_encoder.rs
@@ -3,7 +3,10 @@
 use crate::{
     TokenType,
     WCResult,
-    alloc::{sync::Arc, vec::Vec},
+    alloc::{
+        sync::Arc,
+        vec::Vec,
+    },
     spanners::TextSpanner,
     vocab::SpecialVocab,
 };
@@ -46,8 +49,8 @@ pub trait TokenEncoder<T: TokenType>: Send + Sync {
 
     /// Encode bytes into tokens.
     ///
-    /// There are significant performance gains to pre-allocating the target buffer
-    /// to an appropriate size.
+    /// There are significant performance gains to pre-allocating the target
+    /// buffer to an appropriate size.
     ///
     /// ## Arguments
     /// * `text` - The string slice to encode.
@@ -76,7 +79,8 @@ pub trait TokenEncoder<T: TokenType>: Send + Sync {
         Ok(tokens)
     }
 
-    /// Encode a batch of text into tokens, returning an error if the encoding fails.
+    /// Encode a batch of text into tokens, returning an error if the encoding
+    /// fails.
     ///
     /// ## Arguments
     /// * `batch` - A slice of strings to encode.

--- a/crates/wordchipper/src/encoders/token_span_encoder/mod.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/mod.rs
@@ -6,6 +6,8 @@ pub mod span_encoders;
 mod token_span_encoder;
 
 #[doc(inline)]
-pub use span_encoders::{SpanEncoder, SpanEncoderSelector};
+pub use span_encoders::SpanEncoder;
+#[doc(inline)]
+pub use span_encoders::SpanEncoderSelector;
 #[doc(inline)]
 pub use token_span_encoder::*;

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/bpe_backtrack_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/bpe_backtrack_encoder.rs
@@ -6,15 +6,28 @@
 //! Uses an Aho-Corasick automaton for leftmost-longest token matching,
 //! combined with a backtracking loop that validates BPE merge boundaries.
 
-use alloc::{sync::Arc, vec, vec::Vec};
+use alloc::{
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
 
-use aho_corasick::{AhoCorasick, MatchKind};
+use aho_corasick::{
+    AhoCorasick,
+    MatchKind,
+};
 
 use crate::{
     TokenType,
     encoders::token_span_encoder::SpanEncoder,
-    types::{Pair, WCHashMap},
-    vocab::{UnifiedTokenVocab, VocabIndex},
+    types::{
+        Pair,
+        WCHashMap,
+    },
+    vocab::{
+        UnifiedTokenVocab,
+        VocabIndex,
+    },
 };
 
 /// Precomputed BPE vocabulary data for the backtracking encoder.
@@ -26,7 +39,8 @@ pub struct BpeVocab<T> {
     /// Indexed by `T.to_usize()`. Inverse of `pair_lookup`.
     /// Byte-level tokens map to `(self, self)`.
     split_table: Vec<Pair<T>>,
-    /// For each token, the next-longest prefix token (or `T::max_value()` sentinel).
+    /// For each token, the next-longest prefix token (or `T::max_value()`
+    /// sentinel).
     next_prefix: Vec<T>,
     /// Aho-Corasick automaton over all token byte sequences.
     ac: AhoCorasick,
@@ -63,7 +77,8 @@ impl<T: TokenType> BpeVocab<T> {
             .build(&patterns)
             .expect("failed to build AhoCorasick automaton");
 
-        // Build next_prefix: for each token, the longest prefix token shorter by 1+ bytes.
+        // Build next_prefix: for each token, the longest prefix token shorter by 1+
+        // bytes.
         let mut next_prefix = vec![T::max_value(); table_size];
         for (bytes, tok) in &span_pairs {
             if bytes.len() > 1
@@ -336,8 +351,14 @@ mod tests {
         TokenEncoder,
         TokenType,
         encoders::{
-            testing::{common_encoder_test_vocab, common_encoder_tests},
-            token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
+            token_span_encoder::{
+                SpanEncoderSelector,
+                TokenSpanEncoder,
+            },
         },
         spanners::TextSpannerBuilder,
         vocab::UnifiedTokenVocab,

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/buffer_sweep_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/buffer_sweep_encoder.rs
@@ -67,8 +67,14 @@ mod tests {
         TokenType,
         alloc::sync::Arc,
         encoders::{
-            testing::{common_encoder_test_vocab, common_encoder_tests},
-            token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
+            token_span_encoder::{
+                SpanEncoderSelector,
+                TokenSpanEncoder,
+            },
         },
         spanners::TextSpannerBuilder,
     };

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/merge_heap_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/merge_heap_encoder.rs
@@ -95,8 +95,14 @@ mod tests {
         TokenType,
         alloc::sync::Arc,
         encoders::{
-            testing::{common_encoder_test_vocab, common_encoder_tests},
-            token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
+            token_span_encoder::{
+                SpanEncoderSelector,
+                TokenSpanEncoder,
+            },
         },
         spanners::TextSpannerBuilder,
     };

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/priority_merge_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/priority_merge_encoder.rs
@@ -1,7 +1,8 @@
 //! # Priority-merge [`SpanEncoder`].
 //!
 //! Uses a binary min-heap over a doubly-linked list for O(n log n) BPE merging,
-//! replacing the O(n^2) linear-scan approach in [`super::TailSweepSpanEncoder`].
+//! replacing the O(n^2) linear-scan approach in
+//! [`super::TailSweepSpanEncoder`].
 
 use alloc::collections::BinaryHeap;
 use core::cmp::Reverse;
@@ -23,8 +24,8 @@ struct Node<T> {
 
 /// Heap entry representing a potential merge.
 ///
-/// Ordered by (rank, `left_idx`) so the lowest-rank, leftmost pair is popped first.
-/// `left_tok` and `right_tok` are stored for O(1) stale-entry detection.
+/// Ordered by (rank, `left_idx`) so the lowest-rank, leftmost pair is popped
+/// first. `left_tok` and `right_tok` are stored for O(1) stale-entry detection.
 #[derive(Eq)]
 struct MergeEntry<T: Ord> {
     rank: T,
@@ -209,8 +210,14 @@ mod tests {
         TokenType,
         alloc::sync::Arc,
         encoders::{
-            testing::{common_encoder_test_vocab, common_encoder_tests},
-            token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
+            token_span_encoder::{
+                SpanEncoderSelector,
+                TokenSpanEncoder,
+            },
         },
         spanners::TextSpannerBuilder,
     };

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder.rs
@@ -1,4 +1,9 @@
-use crate::{TokenType, UnifiedTokenVocab, alloc::vec::Vec, spanners::SpanRef};
+use crate::{
+    TokenType,
+    UnifiedTokenVocab,
+    alloc::vec::Vec,
+    spanners::SpanRef,
+};
 
 /// A trait for encoding text spans into tokens.
 pub trait SpanEncoder<T: TokenType>: Send {

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder_selector.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/span_encoder_selector.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     TokenType,
-    alloc::{boxed::Box, sync::Arc},
+    alloc::{
+        boxed::Box,
+        sync::Arc,
+    },
     encoders::token_span_encoder::{
         SpanEncoder,
         span_encoders::{
@@ -10,7 +13,10 @@ use crate::{
             MergeHeapSpanEncoder,
             PriorityMergeSpanEncoder,
             TailSweepSpanEncoder,
-            bpe_backtrack_encoder::{BpeBacktrackSpanEncoder, BpeVocab},
+            bpe_backtrack_encoder::{
+                BpeBacktrackSpanEncoder,
+                BpeVocab,
+            },
         },
     },
     vocab::UnifiedTokenVocab,
@@ -25,7 +31,8 @@ use crate::{
 pub enum SpanEncoderSelector {
     /// This is the canonical best concurrent encoder.
     ///
-    /// It is benchmarked to be the fastest and most efficient encoder for concurrent use.
+    /// It is benchmarked to be the fastest and most efficient encoder for
+    /// concurrent use.
     ///
     /// This is currently an alias for: [`MergeHeap`](`Self::MergeHeap`)
     #[default]
@@ -33,15 +40,17 @@ pub enum SpanEncoderSelector {
 
     /// This the canonical best single-threaded encoder.
     ///
-    /// It is benchmarked to be the fastest and most efficient encoder for single-threaded use.
+    /// It is benchmarked to be the fastest and most efficient encoder for
+    /// single-threaded use.
     ///
     /// This is currently an alias for: [`PriorityMerge`](`Self::PriorityMerge`)
     SingleThreadDefault,
 
     /// The canonical reference encoder, [`BufferSweepSpanEncoder`].
     ///
-    /// This encoder is meant to be used as a reference implementation for testing and comparison.
-    /// The code and behavior are as simple as possible, but it is not optimized for performance.
+    /// This encoder is meant to be used as a reference implementation for
+    /// testing and comparison. The code and behavior are as simple as
+    /// possible, but it is not optimized for performance.
     ///
     /// This is currently an alias for: [`BufferSweep`](`Self::BufferSweep`)
     Reference,
@@ -65,8 +74,8 @@ pub enum SpanEncoderSelector {
 impl SpanEncoderSelector {
     /// Get a builder for the configured [`SpanEncoder`].
     ///
-    /// The `vocab` parameter is needed by encoders that pre-build data structures
-    /// from the vocabulary (e.g. BPE automaton).
+    /// The `vocab` parameter is needed by encoders that pre-build data
+    /// structures from the vocabulary (e.g. BPE automaton).
     pub fn span_encoder_builder<T: TokenType>(
         &self,
         vocab: &UnifiedTokenVocab<T>,

--- a/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/tail_sweep_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/span_encoders/tail_sweep_encoder.rs
@@ -64,8 +64,14 @@ mod tests {
         TokenType,
         alloc::sync::Arc,
         encoders::{
-            testing::{common_encoder_test_vocab, common_encoder_tests},
-            token_span_encoder::{SpanEncoderSelector, TokenSpanEncoder},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
+            token_span_encoder::{
+                SpanEncoderSelector,
+                TokenSpanEncoder,
+            },
         },
         spanners::TextSpannerBuilder,
     };

--- a/crates/wordchipper/src/encoders/token_span_encoder/token_span_encoder.rs
+++ b/crates/wordchipper/src/encoders/token_span_encoder/token_span_encoder.rs
@@ -3,8 +3,15 @@ use crate::{
     TokenType,
     UnifiedTokenVocab,
     WCResult,
-    alloc::{boxed::Box, sync::Arc, vec::Vec},
-    encoders::token_span_encoder::{SpanEncoder, SpanEncoderSelector},
+    alloc::{
+        boxed::Box,
+        sync::Arc,
+        vec::Vec,
+    },
+    encoders::token_span_encoder::{
+        SpanEncoder,
+        SpanEncoderSelector,
+    },
     spanners::TextSpanner,
     vocab::SpecialVocab,
 };

--- a/crates/wordchipper/src/lib.rs
+++ b/crates/wordchipper/src/lib.rs
@@ -7,21 +7,26 @@
 //! ## Client Summary
 //!
 //! ### Core Client Types
-//! * [`TokenType`] - the parameterized integer type used for tokens; choose from `{ u16, u32, u64 }`.
+//! * [`TokenType`] - the parameterized integer type used for tokens; choose
+//!   from `{ u16, u32, u64 }`.
 //! * [`UnifiedTokenVocab<T>`] - the unified vocabulary type.
-//! * [`TokenEncoder<T>`] and [`TokenDecoder<T>`] - the encoder and decoder interfaces.
+//! * [`TokenEncoder<T>`] and [`TokenDecoder<T>`] - the encoder and decoder
+//!   interfaces.
 //!
 //! ### Pre-Trained Models
-//! * [`WordchipperDiskCache`](`disk_cache::WordchipperDiskCache`) - the disk cache for loading models.
-//! * [`OATokenizer`](`pretrained::openai::OATokenizer`) - public pre-trained `OpenAI` tokenizers.
+//! * [`WordchipperDiskCache`](`disk_cache::WordchipperDiskCache`) - the disk
+//!   cache for loading models.
+//! * [`OATokenizer`](`pretrained::openai::OATokenizer`) - public pre-trained
+//!   `OpenAI` tokenizers.
 //!
 //! ## `TokenType` and `WCHash`* Types
 //!
-//! `wordchipper` is parameterized over an abstract primitive integer [`TokenType`].
-//! This permits vocabularies and tokenizers in the `{ u16, u32, u64 }` types.
+//! `wordchipper` is parameterized over an abstract primitive integer
+//! [`TokenType`]. This permits vocabularies and tokenizers in the `{ u16, u32,
+//! u64 }` types.
 //!
-//! It is also feature-parameterized over the [`WCHashSet`] and [`WCHashMap`] types,
-//! which are used to represent sets and maps of tokens.
+//! It is also feature-parameterized over the [`WCHashSet`] and [`WCHashMap`]
+//! types, which are used to represent sets and maps of tokens.
 //! These are provided for convenience and are not required for correctness.
 //!
 //! ## Unified Vocabulary
@@ -29,7 +34,8 @@
 //! The core user-facing vocabulary type is [`UnifiedTokenVocab<T>`].
 //!
 //! Pre-trained vocabulary loaders return [`UnifiedTokenVocab<T>`] instances,
-//! which can be converted between [`TokenType`]s via [`UnifiedTokenVocab::to_token_type`].
+//! which can be converted between [`TokenType`]s via
+//! [`UnifiedTokenVocab::to_token_type`].
 //!
 //! ## Loading and Saving Models
 //!
@@ -69,7 +75,8 @@
 //!
 //! fn example() -> WCResult<Arc<Tokenizer<u32>>> {
 //!     let mut disk_cache = WordchipperDiskCache::default();
-//!     let (_desc, vocab) = load_vocab("openai::o200k_harmony", &mut disk_cache)?;
+//!     let (_desc, vocab) =
+//!         load_vocab("openai::o200k_harmony", &mut disk_cache)?;
 //!     Ok(TokenizerOptions::default().build(vocab))
 //! }
 //! ```
@@ -93,7 +100,10 @@ extern crate alloc;
 pub(crate) mod prelude {
     pub use alloc::{
         boxed::Box,
-        string::{String, ToString},
+        string::{
+            String,
+            ToString,
+        },
         vec::Vec,
     };
 }
@@ -113,16 +123,26 @@ mod tokenizer;
 mod types;
 
 #[doc(inline)]
-pub use decoders::{TokenDecoder, TokenDecoderOptions};
+pub use decoders::TokenDecoder;
 #[doc(inline)]
-pub use encoders::{TokenEncoder, TokenEncoderOptions};
+pub use decoders::TokenDecoderOptions;
+#[doc(inline)]
+pub use encoders::TokenEncoder;
+#[doc(inline)]
+pub use encoders::TokenEncoderOptions;
 #[doc(inline)]
 pub use errors::*;
 #[doc(inline)]
-pub use pretrained::{list_models, list_vocabs, load_vocab};
+pub use pretrained::list_models;
+#[doc(inline)]
+pub use pretrained::list_vocabs;
+#[doc(inline)]
+pub use pretrained::load_vocab;
 #[doc(inline)]
 pub use tokenizer::*;
 #[doc(inline)]
 pub use types::*;
 #[doc(inline)]
-pub use vocab::{UnifiedTokenVocab, VocabIndex};
+pub use vocab::UnifiedTokenVocab;
+#[doc(inline)]
+pub use vocab::VocabIndex;

--- a/crates/wordchipper/src/pretrained/mod.rs
+++ b/crates/wordchipper/src/pretrained/mod.rs
@@ -24,7 +24,8 @@
 //!
 //! fn example() -> wordchipper::WCResult<Arc<Tokenizer<u32>>> {
 //!     let mut disk_cache = WordchipperDiskCache::default();
-//!     let (_desc, vocab) = load_vocab("openai::o200k_harmony", &mut disk_cache)?;
+//!     let (_desc, vocab) =
+//!         load_vocab("openai::o200k_harmony", &mut disk_cache)?;
 //!
 //!     let tokenizer = TokenizerOptions::default().build(vocab.into());
 //!

--- a/crates/wordchipper/src/pretrained/openai/factories.rs
+++ b/crates/wordchipper/src/pretrained/openai/factories.rs
@@ -1,39 +1,54 @@
 //! # `OpenAI` Pretrained Vocabulary Loaders
 
 #[cfg(feature = "std")]
-use std::{io::BufRead, path::Path};
+use std::io::BufRead;
+#[cfg(feature = "std")]
+use std::path::Path;
 
+#[allow(unused_imports)]
+use crate::TokenType;
+#[allow(unused_imports)]
+use crate::UnifiedTokenVocab;
+#[allow(unused_imports)]
+use crate::prelude::*;
+#[allow(unused_imports)]
+use crate::pretrained::openai::OA_CL100K_BASE_PATTERN;
+#[allow(unused_imports)]
+use crate::pretrained::openai::OA_O200K_BASE_PATTERN;
+#[allow(unused_imports)]
+use crate::pretrained::openai::OA_P50K_BASE_PATTERN;
+#[allow(unused_imports)]
+use crate::pretrained::openai::OA_R50K_BASE_PATTERN;
+#[allow(unused_imports)]
+use crate::pretrained::openai::resources::OA_CL100K_BASE_TIKTOKEN_RESOURCE;
+#[allow(unused_imports)]
+use crate::pretrained::openai::resources::OA_O200K_BASE_TIKTOKEN_RESOURCE;
+#[allow(unused_imports)]
+use crate::pretrained::openai::resources::OA_P50K_BASE_TIKTOKEN_RESOURCE;
+#[allow(unused_imports)]
+use crate::pretrained::openai::resources::OA_R50K_BASE_TIKTOKEN_RESOURCE;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_cl100k_edit_special_tokens;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_o200k_base_special_tokens;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_o200k_harmony_special_tokens;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_p50k_base_special_tokens;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_p50k_edit_special_tokens;
+#[allow(unused_imports)]
+use crate::pretrained::openai::specials::oa_r50k_base_special_tokens;
+#[allow(unused_imports)]
+use crate::spanners::TextSpanningConfig;
+#[allow(unused_imports)]
+use crate::support::regex::RegexPattern;
+#[allow(unused_imports)]
+use crate::support::resources::ConstKeyedResource;
 #[cfg(feature = "std")]
 use crate::support::resources::ResourceLoader;
 #[allow(unused_imports)]
-use crate::{
-    TokenType,
-    UnifiedTokenVocab,
-    prelude::*,
-    pretrained::openai::{
-        OA_CL100K_BASE_PATTERN,
-        OA_O200K_BASE_PATTERN,
-        OA_P50K_BASE_PATTERN,
-        OA_R50K_BASE_PATTERN,
-        resources::{
-            OA_CL100K_BASE_TIKTOKEN_RESOURCE,
-            OA_O200K_BASE_TIKTOKEN_RESOURCE,
-            OA_P50K_BASE_TIKTOKEN_RESOURCE,
-            OA_R50K_BASE_TIKTOKEN_RESOURCE,
-        },
-        specials::{
-            oa_cl100k_edit_special_tokens,
-            oa_o200k_base_special_tokens,
-            oa_o200k_harmony_special_tokens,
-            oa_p50k_base_special_tokens,
-            oa_p50k_edit_special_tokens,
-            oa_r50k_base_special_tokens,
-        },
-    },
-    spanners::TextSpanningConfig,
-    support::{regex::RegexPattern, resources::ConstKeyedResource},
-    vocab::utility::factories::ConstVocabularyFactory,
-};
+use crate::vocab::utility::factories::ConstVocabularyFactory;
 
 /// Load the `DataGym` GPT-2 span map vocabulary.
 #[cfg(all(feature = "std", feature = "datagym"))]
@@ -45,9 +60,15 @@ pub fn load_gpt2_vocab<T: TokenType>(
     use crate::{
         pretrained::openai::{
             oa_r50k_base_spanning_config,
-            resources::{OA_GPT2_ENCODER_JSON_KEYED_RESOURCE, OA_GPT2_VOCAB_BPE_KEYED_RESOURCE},
+            resources::{
+                OA_GPT2_ENCODER_JSON_KEYED_RESOURCE,
+                OA_GPT2_VOCAB_BPE_KEYED_RESOURCE,
+            },
         },
-        vocab::{SpanMapVocab, io::read_datagym_vocab},
+        vocab::{
+            SpanMapVocab,
+            io::read_datagym_vocab,
+        },
     };
 
     let vocab_path = loader.load_resource_path(&OA_GPT2_VOCAB_BPE_KEYED_RESOURCE.into())?;

--- a/crates/wordchipper/src/pretrained/openai/patterns.rs
+++ b/crates/wordchipper/src/pretrained/openai/patterns.rs
@@ -1,6 +1,9 @@
 //! # `OpenAI` Patterns
 
-use crate::{join_patterns, support::regex::ConstRegexPattern};
+use crate::{
+    join_patterns,
+    support::regex::ConstRegexPattern,
+};
 
 /// The original "`gpt2`" vocabulary word pattern.
 ///

--- a/crates/wordchipper/src/pretrained/openai/provider.rs
+++ b/crates/wordchipper/src/pretrained/openai/provider.rs
@@ -2,9 +2,16 @@ use crate::{
     UnifiedTokenVocab,
     WCError,
     WCResult,
-    alloc::{sync::Arc, vec::Vec},
+    alloc::{
+        sync::Arc,
+        vec::Vec,
+    },
     prelude::*,
-    pretrained::{VocabDescription, VocabProvider, VocabProviderInventoryHook},
+    pretrained::{
+        VocabDescription,
+        VocabProvider,
+        VocabProviderInventoryHook,
+    },
     support::resources::ResourceLoader,
 };
 

--- a/crates/wordchipper/src/pretrained/openai/resources.rs
+++ b/crates/wordchipper/src/pretrained/openai/resources.rs
@@ -1,6 +1,9 @@
 //! # Public `OpenAI` Resources
 
-use crate::support::resources::{ConstKeyedResource, ConstUrlResource};
+use crate::support::resources::{
+    ConstKeyedResource,
+    ConstUrlResource,
+};
 
 /// Cache-keyed GPT-2 `DataGym` "vocab.bpe" vocabulary resource.
 pub const OA_GPT2_VOCAB_BPE_KEYED_RESOURCE: ConstKeyedResource = ConstKeyedResource {

--- a/crates/wordchipper/src/pretrained/openai/spanning.rs
+++ b/crates/wordchipper/src/pretrained/openai/spanning.rs
@@ -29,7 +29,8 @@ pub fn oa_p50k_edit_spanning_config<T: TokenType>() -> TextSpanningConfig<T> {
         .with_special_words(specials::oa_p50k_edit_special_tokens())
 }
 
-/// Get the [`TextSpanningConfig`] for the "`cl100k_base`" pretrained vocabulary.
+/// Get the [`TextSpanningConfig`] for the "`cl100k_base`" pretrained
+/// vocabulary.
 pub fn oa_cl100k_base_spanning_config<T: TokenType>() -> TextSpanningConfig<T> {
     TextSpanningConfig::<T>::from_pattern(OA_CL100K_BASE_PATTERN)
         .with_special_words(specials::oa_cl100k_edit_special_tokens())
@@ -41,7 +42,8 @@ pub fn oa_o200k_base_spanning_config<T: TokenType>() -> TextSpanningConfig<T> {
         .with_special_words(specials::oa_o200k_base_special_tokens())
 }
 
-/// Get the [`TextSpanningConfig`] for the "`o200k_harmony`" pretrained vocabulary.
+/// Get the [`TextSpanningConfig`] for the "`o200k_harmony`" pretrained
+/// vocabulary.
 pub fn oa_o200k_harmony_spanning_config<T: TokenType>() -> TextSpanningConfig<T> {
     TextSpanningConfig::<T>::from_pattern(OA_O200K_BASE_PATTERN)
         .with_special_words(specials::oa_o200k_harmony_special_tokens())

--- a/crates/wordchipper/src/pretrained/openai/specials.rs
+++ b/crates/wordchipper/src/pretrained/openai/specials.rs
@@ -3,11 +3,17 @@
 use crate::{
     TokenType,
     alloc::{
-        string::{String, ToString},
+        string::{
+            String,
+            ToString,
+        },
         vec::Vec,
     },
     declare_carrot_special,
-    vocab::utility::{ToTokenList, format_reserved_carrot},
+    vocab::utility::{
+        ToTokenList,
+        format_reserved_carrot,
+    },
 };
 
 declare_carrot_special!(
@@ -137,7 +143,11 @@ pub fn oa_o200k_harmony_special_tokens<T: TokenType>() -> Vec<(String, T)> {
 mod tests {
     use super::*;
     use crate::{
-        alloc::{string::ToString, vec, vec::Vec},
+        alloc::{
+            string::ToString,
+            vec,
+            vec::Vec,
+        },
         vocab::utility::format_reserved_carrot,
     };
 

--- a/crates/wordchipper/src/pretrained/vocab_factory.rs
+++ b/crates/wordchipper/src/pretrained/vocab_factory.rs
@@ -7,7 +7,11 @@ use crate::{
     UnifiedTokenVocab,
     WCError,
     WCResult,
-    alloc::{format, string::String, sync::Arc},
+    alloc::{
+        format,
+        string::String,
+        sync::Arc,
+    },
     prelude::*,
     support::resources::ResourceLoader,
 };
@@ -197,7 +201,8 @@ impl VocabFactory {
     ///
     /// ## Returns
     /// * `Ok(())` - on success,
-    /// * `Err(WCError::DuplicatedResource)` - if a provider with the same name already exists
+    /// * `Err(WCError::DuplicatedResource)` - if a provider with the same name
+    ///   already exists
     pub fn register_provider(
         &mut self,
         provider: Arc<dyn VocabProvider>,

--- a/crates/wordchipper/src/spanners/mod.rs
+++ b/crates/wordchipper/src/spanners/mod.rs
@@ -4,9 +4,11 @@
 //!
 //! [`TextSpanningConfig`] describes the declarative needs of a tokenizer:
 //! * `pattern` - the word/span split pattern.
-//! * `specials` - a map of `{ Vec<u8> -> T }` special tokens to handle out-of-band.
+//! * `specials` - a map of `{ Vec<u8> -> T }` special tokens to handle
+//!   out-of-band.
 //!
-//! Most users will want to use the [`TextSpannerBuilder`] to construct a [`TextSpanner`].
+//! Most users will want to use the [`TextSpannerBuilder`] to construct a
+//! [`TextSpanner`].
 
 pub mod span_lexers;
 

--- a/crates/wordchipper/src/spanners/span_lexers/accelerators.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/accelerators.rs
@@ -71,11 +71,15 @@ pub mod testutil {
 
     use super::*;
     use crate::{
-        alloc::{format, vec},
+        alloc::{
+            format,
+            vec,
+        },
         prelude::*,
     };
 
-    /// Testing utility for checking that a sample and an accelerated span lexer match.
+    /// Testing utility for checking that a sample and an accelerated span lexer
+    /// match.
     pub fn assert_matches_reference_lexer(
         sample: &str,
         ref_lexer: &dyn SpanLexer,

--- a/crates/wordchipper/src/spanners/span_lexers/lexer_builder.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/lexer_builder.rs
@@ -4,8 +4,14 @@ use core::num::NonZeroUsize;
 
 use crate::{
     alloc::sync::Arc,
-    spanners::span_lexers::{SpanLexer, accelerators},
-    support::regex::{RegexPattern, RegexWrapper},
+    spanners::span_lexers::{
+        SpanLexer,
+        accelerators,
+    },
+    support::regex::{
+        RegexPattern,
+        RegexWrapper,
+    },
 };
 
 /// Build a regex-based [`SpanLexer`] with the given configuration.
@@ -13,8 +19,8 @@ use crate::{
 /// ## Arguments
 /// * `pattern` - the pattern.
 /// * `concurrent` - whether to use a concurrent pool.
-/// * `max_pool` - the max size of the concurrent pool;
-///   `None` will use system/environment defaults.
+/// * `max_pool` - the max size of the concurrent pool; `None` will use
+///   system/environment defaults.
 pub fn build_regex_lexer(
     pattern: RegexPattern,
     accelerated: bool,

--- a/crates/wordchipper/src/spanners/span_lexers/lexer_spanner.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/lexer_spanner.rs
@@ -4,7 +4,11 @@ use core::ops::Range;
 
 use crate::{
     alloc::sync::Arc,
-    spanners::{SpanRef, TextSpanner, span_lexers::SpanLexer},
+    spanners::{
+        SpanRef,
+        TextSpanner,
+        span_lexers::SpanLexer,
+    },
     support::ranges::offset_range,
 };
 
@@ -48,7 +52,8 @@ impl LexerTextSpanner {
             .and_then(|s| s.find_span_iter(text).next())
     }
 
-    /// Scan `text` into [`Word`](SpanRef::Word) and [`Gap`](SpanRef::Gap) spans.
+    /// Scan `text` into [`Word`](SpanRef::Word) and [`Gap`](SpanRef::Gap)
+    /// spans.
     ///
     /// Loops over [`next_span`](Self::next_span),
     /// classifying matched regions as `Word` and unmatched regions as `Gap`.
@@ -132,9 +137,16 @@ mod tests {
     use super::*;
     use crate::{
         TokenType,
-        alloc::{boxed::Box, vec, vec::Vec},
+        alloc::{
+            boxed::Box,
+            vec,
+            vec::Vec,
+        },
         pretrained::openai::OA_CL100K_BASE_PATTERN,
-        spanners::{SpanRef, TextSpanningConfig},
+        spanners::{
+            SpanRef,
+            TextSpanningConfig,
+        },
     };
 
     const _LEXER_SPANNER_BOX_CHECK: Option<Box<LexerTextSpanner>> = None;

--- a/crates/wordchipper/src/spanners/span_lexers/logos/cl100k.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/logos/cl100k.rs
@@ -3,17 +3,28 @@
 //! Compile-time DFA lexer for the `cl100k_base` pattern (GPT-4, GPT-3.5).
 //!
 //! This serves as a reference implementation showing how to build an
-//! accelerated lexer using [`Gpt2FamilyTokenRole`] and [`for_each_classified_span`].
+//! accelerated lexer using [`Gpt2FamilyTokenRole`] and
+//! [`for_each_classified_span`].
 
 use core::ops::Range;
 
 use logos::Logos;
 
-use super::gpt2_family::{Gpt2FamilyLogos, Gpt2FamilySpanIter, Gpt2FamilyTokenRole};
+use super::gpt2_family::{
+    Gpt2FamilyLogos,
+    Gpt2FamilySpanIter,
+    Gpt2FamilyTokenRole,
+};
 use crate::{
-    alloc::{boxed::Box, sync::Arc},
+    alloc::{
+        boxed::Box,
+        sync::Arc,
+    },
     pretrained::openai::OA_CL100K_BASE_PATTERN,
-    spanners::span_lexers::{SpanLexer, accelerators::RegexAcceleratorHook},
+    spanners::span_lexers::{
+        SpanLexer,
+        accelerators::RegexAcceleratorHook,
+    },
 };
 
 /// Logos token for the `cl100k_base` pattern.
@@ -91,8 +102,17 @@ impl SpanLexer for Cl100kLexer {
 mod tests {
     use super::*;
     use crate::{
-        alloc::{string::ToString, sync::Arc, vec, vec::Vec},
-        spanners::{SpanRef, TextSpanner, span_lexers::LexerTextSpanner},
+        alloc::{
+            string::ToString,
+            sync::Arc,
+            vec,
+            vec::Vec,
+        },
+        spanners::{
+            SpanRef,
+            TextSpanner,
+            span_lexers::LexerTextSpanner,
+        },
     };
 
     /// Build a `TextSpanner` from a logos lexer with no specials.
@@ -197,7 +217,10 @@ mod tests {
     fn test_logos_cl100k_unicode() {
         use crate::{
             pretrained::openai::OA_CL100K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -233,7 +256,10 @@ mod tests {
     fn test_logos_cl100k_realworld() {
         use crate::{
             pretrained::openai::OA_CL100K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -281,7 +307,10 @@ mod tests {
     fn test_logos_cl100k_long_text() {
         use crate::{
             pretrained::openai::OA_CL100K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -434,7 +463,10 @@ mod tests {
 
         use crate::{
             pretrained::openai::OA_CL100K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =

--- a/crates/wordchipper/src/spanners/span_lexers/logos/gpt2_family.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/logos/gpt2_family.rs
@@ -3,13 +3,19 @@
 //! Classification of logos tokens for whitespace post-processing.
 //!
 //! When building a custom accelerated lexer, each logos token variant maps
-//! to a [`Gpt2FamilyTokenRole`] that tells the post-processing engine how the token
-//! interacts with preceding whitespace.
+//! to a [`Gpt2FamilyTokenRole`] that tells the post-processing engine how the
+//! token interacts with preceding whitespace.
 
 use core::ops::Range;
 
-use logos::{Logos, SpannedIter};
-use ringbuf::traits::{Consumer, Producer};
+use logos::{
+    Logos,
+    SpannedIter,
+};
+use ringbuf::traits::{
+    Consumer,
+    Producer,
+};
 
 use crate::spanners::SpanRef;
 
@@ -38,9 +44,9 @@ pub enum Gpt2FamilyTokenRole {
     Whitespace,
     /// Punctuation with ` ?` prefix. Always absorbs a preceding ASCII space.
     Punctuation,
-    /// Letter/word token. Absorbs preceding space if token starts with a letter.
-    /// When `check_contraction` is true, applies contraction-prefix splitting
-    /// (e.g. `'The` -> `'T` + `he` for cl100k compatibility).
+    /// Letter/word token. Absorbs preceding space if token starts with a
+    /// letter. When `check_contraction` is true, applies contraction-prefix
+    /// splitting (e.g. `'The` -> `'T` + `he` for cl100k compatibility).
     Word {
         /// Whether to check for and split contraction prefixes.
         check_contraction: bool,
@@ -344,13 +350,13 @@ where
 ///
 /// 2. **Prefix handling**: with 2+ whitespace chars before a token starting
 ///    with a non-letter, we merge the last whitespace byte + the non-letter
-///    prefix into one span (matching how Punctuation's ` ?` absorbs a space
-///    in the regex). With 1 whitespace char, it stays standalone.
+///    prefix into one span (matching how Punctuation's ` ?` absorbs a space in
+///    the regex). With 1 whitespace char, it stays standalone.
 ///
 /// 3. **Contraction splitting** (when `check_contraction` is true): regex
 ///    first-match picks Contraction `'T` over Letters `'The`, but logos
-///    longest-match picks Letters. We detect the contraction prefix and
-///    split the token.
+///    longest-match picks Letters. We detect the contraction prefix and split
+///    the token.
 ///
 /// # Arguments
 ///
@@ -369,7 +375,10 @@ where
 /// ```
 /// use wordchipper::spanners::{
 ///     SpanRef,
-///     span_lexers::logos::gpt2_family::{Gpt2FamilyTokenRole, for_each_classified_span},
+///     span_lexers::logos::gpt2_family::{
+///         Gpt2FamilyTokenRole,
+///         for_each_classified_span,
+///     },
 /// };
 ///
 /// let text = "hello world";
@@ -579,7 +588,10 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::{alloc::vec::Vec, spanners::span_lexers::logos::gpt2_family::Gpt2FamilyTokenRole};
+    use crate::{
+        alloc::vec::Vec,
+        spanners::span_lexers::logos::gpt2_family::Gpt2FamilyTokenRole,
+    };
 
     /// Collect spans from for_each_classified_span for testing.
     fn collect_spans(

--- a/crates/wordchipper/src/spanners/span_lexers/logos/mod.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/logos/mod.rs
@@ -6,9 +6,10 @@
 //! ## Building a custom lexer
 //!
 //! 1. Define a `#[derive(Logos)]` enum with your token patterns.
-//! 2. Map each variant to a [`Gpt2FamilyTokenRole`] (via a `role()` method or similar).
-//! 3. Implement [`SpanLexer`](super::SpanLexer) by feeding the token stream
-//!    to [`for_each_classified_span`].
+//! 2. Map each variant to a [`Gpt2FamilyTokenRole`] (via a `role()` method or
+//!    similar).
+//! 3. Implement [`SpanLexer`](super::SpanLexer) by feeding the token stream to
+//!    [`for_each_classified_span`].
 //!
 //! See [`Cl100kLexer`] and [`O200kLexer`] for reference implementations.
 

--- a/crates/wordchipper/src/spanners/span_lexers/logos/o200k.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/logos/o200k.rs
@@ -3,19 +3,27 @@
 //! Compile-time DFA lexer for the `o200k_base` pattern (GPT-4o).
 //!
 //! This serves as a reference implementation showing how to build an
-//! accelerated lexer using [`Gpt2FamilyTokenRole`] and [`for_each_classified_span`].
+//! accelerated lexer using [`Gpt2FamilyTokenRole`] and
+//! [`for_each_classified_span`].
 
 use core::ops::Range;
 
 use logos::Logos;
 
 use crate::{
-    alloc::{boxed::Box, sync::Arc},
+    alloc::{
+        boxed::Box,
+        sync::Arc,
+    },
     pretrained::openai::OA_O200K_BASE_PATTERN,
     spanners::span_lexers::{
         SpanLexer,
         accelerators::RegexAcceleratorHook,
-        logos::gpt2_family::{Gpt2FamilyLogos, Gpt2FamilySpanIter, Gpt2FamilyTokenRole},
+        logos::gpt2_family::{
+            Gpt2FamilyLogos,
+            Gpt2FamilySpanIter,
+            Gpt2FamilyTokenRole,
+        },
     },
 };
 // Shorthand aliases for the character classes used in o200k:
@@ -29,9 +37,9 @@ use crate::{
 /// Logos token for the `o200k_base` pattern.
 ///
 /// Key difference from cl100k: contractions are attached to the preceding word.
-/// The two word regex branches are split into separate variants (`WordLower` and
-/// `WordUpper`) to avoid DFA longest-match merging characters like `º` (Lo) with
-/// following uppercase letters. `WordUpper` restricts its leading chars to
+/// The two word regex branches are split into separate variants (`WordLower`
+/// and `WordUpper`) to avoid DFA longest-match merging characters like `º` (Lo)
+/// with following uppercase letters. `WordUpper` restricts its leading chars to
 /// `[\p{Lu}\p{Lt}]` so Lo/Lm/M chars can only match via `WordLower`.
 ///
 /// | Regex branch                                         | Logos variant  |
@@ -116,8 +124,15 @@ impl SpanLexer for O200kLexer {
 mod tests {
     use super::*;
     use crate::{
-        alloc::{sync::Arc, vec::Vec},
-        spanners::{SpanRef, TextSpanner, span_lexers::LexerTextSpanner},
+        alloc::{
+            sync::Arc,
+            vec::Vec,
+        },
+        spanners::{
+            SpanRef,
+            TextSpanner,
+            span_lexers::LexerTextSpanner,
+        },
     };
 
     /// Build a `TextSpanner` from a logos lexer with no specials.
@@ -187,7 +202,10 @@ mod tests {
     fn test_o200k_unicode() {
         use crate::{
             pretrained::openai::OA_O200K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -224,7 +242,10 @@ mod tests {
     fn test_o200k_realworld() {
         use crate::{
             pretrained::openai::OA_O200K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -365,7 +386,10 @@ mod tests {
 
         use crate::{
             pretrained::openai::OA_O200K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =

--- a/crates/wordchipper/src/spanners/span_lexers/logos/r50k.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/logos/r50k.rs
@@ -3,19 +3,27 @@
 //! Compile-time DFA lexer for the `r50k_base` pattern (GPT-2).
 //!
 //! This serves as a reference implementation showing how to build an
-//! accelerated lexer using [`Gpt2FamilyTokenRole`] and [`for_each_classified_span`].
+//! accelerated lexer using [`Gpt2FamilyTokenRole`] and
+//! [`for_each_classified_span`].
 
 use core::ops::Range;
 
 use logos::Logos;
 
 use crate::{
-    alloc::{boxed::Box, sync::Arc},
+    alloc::{
+        boxed::Box,
+        sync::Arc,
+    },
     pretrained::openai::OA_R50K_BASE_PATTERN,
     spanners::span_lexers::{
         SpanLexer,
         accelerators::RegexAcceleratorHook,
-        logos::gpt2_family::{Gpt2FamilyLogos, Gpt2FamilySpanIter, Gpt2FamilyTokenRole},
+        logos::gpt2_family::{
+            Gpt2FamilyLogos,
+            Gpt2FamilySpanIter,
+            Gpt2FamilyTokenRole,
+        },
     },
 };
 
@@ -92,8 +100,17 @@ impl SpanLexer for R50kLexer {
 mod tests {
     use super::*;
     use crate::{
-        alloc::{string::ToString, sync::Arc, vec, vec::Vec},
-        spanners::{SpanRef, TextSpanner, span_lexers::LexerTextSpanner},
+        alloc::{
+            string::ToString,
+            sync::Arc,
+            vec,
+            vec::Vec,
+        },
+        spanners::{
+            SpanRef,
+            TextSpanner,
+            span_lexers::LexerTextSpanner,
+        },
     };
 
     /// Build a `TextSpanner` from a logos lexer with no specials.
@@ -194,7 +211,10 @@ mod tests {
     fn test_logos_r50k_unicode() {
         use crate::{
             pretrained::openai::OA_R50K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -232,7 +252,10 @@ mod tests {
     fn test_logos_r50k_realworld() {
         use crate::{
             pretrained::openai::OA_R50K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -295,7 +318,10 @@ mod tests {
     fn test_logos_r50k_long_text() {
         use crate::{
             pretrained::openai::OA_R50K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =
@@ -452,7 +478,10 @@ mod tests {
 
         use crate::{
             pretrained::openai::OA_R50K_BASE_PATTERN,
-            spanners::{TextSpannerBuilder, TextSpanningConfig},
+            spanners::{
+                TextSpannerBuilder,
+                TextSpanningConfig,
+            },
         };
 
         let config: TextSpanningConfig<u32> =

--- a/crates/wordchipper/src/spanners/span_lexers/span_lexer.rs
+++ b/crates/wordchipper/src/spanners/span_lexers/span_lexer.rs
@@ -1,6 +1,9 @@
 //! # `SpanLexer` trait
 
-use core::ops::{Deref, Range};
+use core::ops::{
+    Deref,
+    Range,
+};
 
 use crate::prelude::*;
 
@@ -8,10 +11,12 @@ use crate::prelude::*;
 ///
 /// ## Implementation Notes
 ///
-/// Smart pointer types that implement `Deref<Target: SpanLexer>` (such as `Arc<T>`, `Box<T>`,
-/// and [`PoolToy<T>`](crate::support::concurrency::PoolToy)) automatically implement `SpanLexer` through
-/// a blanket implementation. This is the idiomatic Rust pattern used by the standard library
-/// for traits like `Iterator` and `Future`.
+/// Smart pointer types that implement `Deref<Target: SpanLexer>` (such as
+/// `Arc<T>`, `Box<T>`,
+/// and [`PoolToy<T>`](crate::support::concurrency::PoolToy)) automatically
+/// implement `SpanLexer` through a blanket implementation. This is the
+/// idiomatic Rust pattern used by the standard library for traits like
+/// `Iterator` and `Future`.
 pub trait SpanLexer: Send + Sync {
     /// Returns an iter over matching spans in the text.
     fn find_span_iter<'a>(
@@ -21,7 +26,8 @@ pub trait SpanLexer: Send + Sync {
 }
 
 // Blanket implementation for any type that derefs to a SpanLexer.
-// This allows Arc<T>, Box<T>, PoolToy<T>, etc. to automatically implement SpanLexer.
+// This allows Arc<T>, Box<T>, PoolToy<T>, etc. to automatically implement
+// SpanLexer.
 impl<D> SpanLexer for D
 where
     D: Deref + Send + Sync,

--- a/crates/wordchipper/src/spanners/spanner_builder.rs
+++ b/crates/wordchipper/src/spanners/spanner_builder.rs
@@ -9,14 +9,19 @@ use crate::{
     spanners::{
         TextSpanner,
         TextSpanningConfig,
-        span_lexers::{LexerTextSpanner, SpanLexer, build_regex_lexer},
+        span_lexers::{
+            LexerTextSpanner,
+            SpanLexer,
+            build_regex_lexer,
+        },
     },
 };
 
 /// Builder for [`TextSpanner`]s.
 ///
 /// The primary tuning knobs here are:
-/// * [`set_concurrent`](Self::set_concurrent) - whether to request a concurrency support.
+/// * [`set_concurrent`](Self::set_concurrent) - whether to request a
+///   concurrency support.
 #[derive(Clone, PartialEq)]
 pub struct TextSpannerBuilder<T: TokenType> {
     config: TextSpanningConfig<T>,

--- a/crates/wordchipper/src/spanners/spanning_config.rs
+++ b/crates/wordchipper/src/spanners/spanning_config.rs
@@ -1,5 +1,10 @@
 //! # Text Spanner Configuration
-use crate::{TokenType, WCResult, support::regex::RegexPattern, vocab::SpecialVocab};
+use crate::{
+    TokenType,
+    WCResult,
+    support::regex::RegexPattern,
+    vocab::SpecialVocab,
+};
 
 /// Description of text spanners configuration.
 ///
@@ -123,7 +128,10 @@ impl<T: TokenType> TextSpanningConfig<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{alloc::string::ToString, vocab::SpecialVocab};
+    use crate::{
+        alloc::string::ToString,
+        vocab::SpecialVocab,
+    };
 
     #[test]
     fn test_from_pattern() {

--- a/crates/wordchipper/src/spanners/text_spanner.rs
+++ b/crates/wordchipper/src/spanners/text_spanner.rs
@@ -3,7 +3,10 @@
 use core::ops::Range;
 
 use crate::{
-    alloc::{string::String, vec::Vec},
+    alloc::{
+        string::String,
+        vec::Vec,
+    },
     vocab::DEFAULT_BYTE_PER_TOKEN_RATIO,
 };
 
@@ -61,8 +64,8 @@ pub trait TextSpanner: Send + Sync {
     ///
     /// # Arguments
     /// * `text` - the text to split.
-    /// * `f` - the function to apply to each span;
-    ///   halts when the function returns `false`.
+    /// * `f` - the function to apply to each span; halts when the function
+    ///   returns `false`.
     ///
     /// Note: a byte is consumed *only if* the function returns `true`;
     /// if the function returns `false`, the byte is not consumed.
@@ -131,7 +134,10 @@ pub trait TextSpanner: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alloc::{boxed::Box, sync::Arc};
+    use crate::alloc::{
+        boxed::Box,
+        sync::Arc,
+    };
 
     const _TEXT_SPANNER_BOX_CHECK: Option<Box<dyn TextSpanner>> = None;
     const _TEXT_SPANNER_ARC_CHECK: Option<Arc<dyn TextSpanner>> = None;

--- a/crates/wordchipper/src/support/concurrency/pool_toy.rs
+++ b/crates/wordchipper/src/support/concurrency/pool_toy.rs
@@ -1,11 +1,17 @@
 //! # Thread Pool Toy
 
-use core::{fmt::Debug, ops::Deref};
+use core::{
+    fmt::Debug,
+    ops::Deref,
+};
 use std::num::NonZeroUsize;
 
 use crate::{
     prelude::*,
-    support::concurrency::threads::{resolve_max_pool, unstable_current_thread_id_hash},
+    support::concurrency::threads::{
+        resolve_max_pool,
+        unstable_current_thread_id_hash,
+    },
 };
 
 /// Current Thread -> T Pool.
@@ -53,7 +59,8 @@ impl<T> PoolToy<T>
 where
     T: Clone + Send,
 {
-    /// Initialize a new thread-local pool with the given item and maximum pool size.
+    /// Initialize a new thread-local pool with the given item and maximum pool
+    /// size.
     ///
     /// ## Arguments
     /// * `pool` - the pool of items.

--- a/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
+++ b/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
@@ -4,7 +4,11 @@ use crate::{
     TokenType,
     WCResult,
     alloc::sync::Arc,
-    decoders::{BatchDecodeResult, DecodeResult, TokenDecoder},
+    decoders::{
+        BatchDecodeResult,
+        DecodeResult,
+        TokenDecoder,
+    },
     prelude::*,
 };
 
@@ -84,7 +88,10 @@ mod tests {
         decoders::utility::testing::common_decoder_unit_test,
         pretrained::openai::OA_CL100K_BASE_PATTERN,
         spanners::TextSpanningConfig,
-        vocab::utility::testing::{build_test_shift_byte_vocab, build_test_vocab},
+        vocab::utility::testing::{
+            build_test_shift_byte_vocab,
+            build_test_vocab,
+        },
     };
 
     #[test]

--- a/crates/wordchipper/src/support/concurrency/rayon/rayon_encoder.rs
+++ b/crates/wordchipper/src/support/concurrency/rayon/rayon_encoder.rs
@@ -83,7 +83,10 @@ mod tests {
         UnifiedTokenVocab,
         encoders::{
             TokenEncoder,
-            testing::{common_encoder_test_vocab, common_encoder_tests},
+            testing::{
+                common_encoder_test_vocab,
+                common_encoder_tests,
+            },
         },
     };
 

--- a/crates/wordchipper/src/support/concurrency/threads.rs
+++ b/crates/wordchipper/src/support/concurrency/threads.rs
@@ -1,6 +1,9 @@
 //! # Thread Utilities
 
-use core::num::{NonZeroU64, NonZeroUsize};
+use core::num::{
+    NonZeroU64,
+    NonZeroUsize,
+};
 use std::thread;
 
 /// Current Thread -> u64 Pool.
@@ -8,10 +11,10 @@ use std::thread;
 /// ``thread::current().id().as_u64()`` is unstable.
 pub fn unstable_current_thread_id_hash() -> usize {
     // c/o `tiktoken`:
-    // It's easier to use unsafe than to use nightly. Rust has this nice u64 thread id counter
-    // that works great for our use case of avoiding collisions in our array. Unfortunately,
-    // it's private. However, there are only so many ways you can layout a u64, so just transmute
-    // https://github.com/rust-lang/rust/issues/67939
+    // It's easier to use unsafe than to use nightly. Rust has this nice u64 thread
+    // id counter that works great for our use case of avoiding collisions in
+    // our array. Unfortunately, it's private. However, there are only so many
+    // ways you can layout a u64, so just transmute https://github.com/rust-lang/rust/issues/67939
 
     struct FakeThreadId(NonZeroU64);
     const _: [u8; 8] = [0; std::mem::size_of::<std::thread::ThreadId>()];
@@ -22,7 +25,8 @@ pub fn unstable_current_thread_id_hash() -> usize {
     u64::from(val) as usize
 }
 
-/// The search list of environment variables that Rayon uses to control parallelism.
+/// The search list of environment variables that Rayon uses to control
+/// parallelism.
 #[cfg(feature = "parallel")]
 const RAYON_VARS: &[&str] = &["RAYON_NUM_THREADS", "RAYON_RS_NUM_CPUS"];
 
@@ -50,7 +54,8 @@ pub fn est_max_parallelism() -> usize {
 
 /// Resolve the max pool size.
 ///
-/// ``min(max_pool, thread::available_parallelism() || MAX_POOL, env::var("RAYON_NUM_THREADS"))``
+/// ``min(max_pool, thread::available_parallelism() || MAX_POOL,
+/// env::var("RAYON_NUM_THREADS"))``
 pub fn resolve_max_pool(max_pool: Option<NonZeroUsize>) -> usize {
     let sys_max = est_max_parallelism();
 
@@ -66,7 +71,10 @@ mod tests {
     use serial_test::serial;
 
     use super::*;
-    use crate::{prelude::*, types::WCHashMap};
+    use crate::{
+        prelude::*,
+        types::WCHashMap,
+    };
 
     #[test]
     #[serial]

--- a/crates/wordchipper/src/support/regex/alt_choice.rs
+++ b/crates/wordchipper/src/support/regex/alt_choice.rs
@@ -1,7 +1,11 @@
 //! Exact Match Union Patterns
 
 use crate::{
-    alloc::{format, string::ToString, vec::Vec},
+    alloc::{
+        format,
+        string::ToString,
+        vec::Vec,
+    },
     support::regex::regex_pattern::RegexPattern,
 };
 
@@ -27,7 +31,10 @@ pub fn alternate_choice_regex_pattern<S: AsRef<str>>(alts: &[S]) -> RegexPattern
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{alloc::vec, support::regex::RegexWrapper};
+    use crate::{
+        alloc::vec,
+        support::regex::RegexWrapper,
+    };
 
     #[test]
     fn test_fixed_alternative_list() {

--- a/crates/wordchipper/src/support/regex/mod.rs
+++ b/crates/wordchipper/src/support/regex/mod.rs
@@ -1,20 +1,24 @@
 //! # Regex Utilities
 //!
-//! A number of popular in-use LLM Tokenizer Regex Patterns require extended regex
-//! machinery provided by the [`fancy_regex`] crate; but naturally, this has performance
-//! costs. We'd prefer to avoid using the [`fancy_regex`] crate when possible, falling back
-//! on the standard [`regex`] crate when patterns permit this.
+//! A number of popular in-use LLM Tokenizer Regex Patterns require extended
+//! regex machinery provided by the [`fancy_regex`] crate; but naturally, this
+//! has performance costs. We'd prefer to avoid using the [`fancy_regex`] crate
+//! when possible, falling back on the standard [`regex`] crate when patterns
+//! permit this.
 //!
 //! This recurses into two problems:
 //!
 //! * Labeling Patterns - [`RegexPattern`]
-//!   * [`RegexPattern::Basic`] - a pattern which was written for basic regular expressions.
-//!   * [`RegexPattern::Fancy`] - a pattern which was written for regex extensions.
-//!   * [`RegexPattern::Adaptive`] - unknown target, try basic; then fall-up to fancy.
+//!   * [`RegexPattern::Basic`] - a pattern which was written for basic regular
+//!     expressions.
+//!   * [`RegexPattern::Fancy`] - a pattern which was written for regex
+//!     extensions.
+//!   * [`RegexPattern::Adaptive`] - unknown target, try basic; then fall-up to
+//!     fancy.
 //! * Wrapping Compiled Regex - [`RegexWrapper`]
 //!
-//! The [`RegexWrapper`] type supports only one operation, ``find_iter()`` which requires
-//! some adaptation of the `Iterator` stream to function.
+//! The [`RegexWrapper`] type supports only one operation, ``find_iter()`` which
+//! requires some adaptation of the `Iterator` stream to function.
 
 mod alt_choice;
 mod regex_pattern;

--- a/crates/wordchipper/src/support/regex/regex_pattern.rs
+++ b/crates/wordchipper/src/support/regex/regex_pattern.rs
@@ -1,8 +1,14 @@
 //! # Regex Pattern Labeled Wrapper
 
 use crate::{
-    alloc::string::{String, ToString},
-    support::regex::{ErrorWrapper, RegexWrapper},
+    alloc::string::{
+        String,
+        ToString,
+    },
+    support::regex::{
+        ErrorWrapper,
+        RegexWrapper,
+    },
 };
 
 /// Const Regex Wrapper Pattern

--- a/crates/wordchipper/src/support/regex/regex_wrapper.rs
+++ b/crates/wordchipper/src/support/regex/regex_wrapper.rs
@@ -1,9 +1,16 @@
 //! # Regex Wrapper
 //! This modules provides mechanisms to mix `regex` and `fancy_regex` types.
 
-use core::{fmt::Debug, ops::Range};
+use core::{
+    fmt::Debug,
+    ops::Range,
+};
 
-use crate::{alloc::boxed::Box, spanners::span_lexers::SpanLexer, support::regex::RegexPattern};
+use crate::{
+    alloc::boxed::Box,
+    spanners::span_lexers::SpanLexer,
+    support::regex::RegexPattern,
+};
 
 /// Error wrapper for regex patterns.
 #[non_exhaustive]
@@ -182,7 +189,10 @@ impl<'r, 'h> Iterator for MatchesWrapper<'r, 'h> {
 mod tests {
     use super::*;
     use crate::{
-        alloc::{format, string::ToString},
+        alloc::{
+            format,
+            string::ToString,
+        },
         join_patterns,
         support::regex::regex_pattern::ConstRegexPattern,
     };

--- a/crates/wordchipper/src/support/resources/url_resource.rs
+++ b/crates/wordchipper/src/support/resources/url_resource.rs
@@ -1,7 +1,10 @@
 //! # Remote Resource Tools
 
 use crate::alloc::{
-    string::{String, ToString},
+    string::{
+        String,
+        ToString,
+    },
     vec::Vec,
 };
 
@@ -72,7 +75,10 @@ impl From<ConstKeyedResource> for KeyedResource {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alloc::{string::ToString, vec};
+    use crate::alloc::{
+        string::ToString,
+        vec,
+    };
 
     #[test]
     fn test_keyed_resource() {

--- a/crates/wordchipper/src/support/strings.rs
+++ b/crates/wordchipper/src/support/strings.rs
@@ -1,6 +1,10 @@
 //! # String Utilities
 
-use crate::alloc::{borrow::Cow, string::String, vec::Vec};
+use crate::alloc::{
+    borrow::Cow,
+    string::String,
+    vec::Vec,
+};
 
 /// "stable" stub for for [`String::from_utf8_lossy`].
 pub fn string_from_utf8_lossy(v: Vec<u8>) -> String {
@@ -19,7 +23,10 @@ pub fn string_from_utf8_lossy(v: Vec<u8>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::alloc::{string::ToString, vec};
+    use crate::alloc::{
+        string::ToString,
+        vec,
+    };
 
     #[test]
     fn test_string_from_lossy_utf8() {

--- a/crates/wordchipper/src/tokenizer/tokenizer_impl.rs
+++ b/crates/wordchipper/src/tokenizer/tokenizer_impl.rs
@@ -5,7 +5,10 @@ use crate::{
     UnifiedTokenVocab,
     WCResult,
     alloc::sync::Arc,
-    decoders::{BatchDecodeResult, DecodeResult},
+    decoders::{
+        BatchDecodeResult,
+        DecodeResult,
+    },
     prelude::*,
     spanners::TextSpanner,
 };

--- a/crates/wordchipper/src/tokenizer/tokenizer_options.rs
+++ b/crates/wordchipper/src/tokenizer/tokenizer_options.rs
@@ -55,7 +55,8 @@ impl TokenizerOptions {
 
     /// Gets the configured parallelism value.
     ///
-    /// Returns true if either encoder or decoder are configured for parallelism.
+    /// Returns true if either encoder or decoder are configured for
+    /// parallelism.
     ///
     /// Enabling parallelism will request threaded implementations.
     pub fn parallel(&self) -> bool {

--- a/crates/wordchipper/src/types.rs
+++ b/crates/wordchipper/src/types.rs
@@ -1,10 +1,18 @@
 //! # Common Types and Traits
 use core::{
-    fmt::{Debug, Display},
+    fmt::{
+        Debug,
+        Display,
+    },
     hash::Hash,
 };
 
-use num_traits::{FromPrimitive, PrimInt, ToPrimitive, Unsigned};
+use num_traits::{
+    FromPrimitive,
+    PrimInt,
+    ToPrimitive,
+    Unsigned,
+};
 
 /// A type that can be used as a token in a BPE-based encoders.
 ///

--- a/crates/wordchipper/src/vocab/byte_vocab.rs
+++ b/crates/wordchipper/src/vocab/byte_vocab.rs
@@ -4,9 +4,20 @@ use core::fmt::Debug;
 
 use crate::{
     WCResult,
-    alloc::{vec, vec::Vec},
-    types::{TokenType, WCHashSet},
-    vocab::{ByteTokenArray, ByteTokenMap, TokenByteMap, VocabIndex},
+    alloc::{
+        vec,
+        vec::Vec,
+    },
+    types::{
+        TokenType,
+        WCHashSet,
+    },
+    vocab::{
+        ByteTokenArray,
+        ByteTokenMap,
+        TokenByteMap,
+        VocabIndex,
+    },
 };
 
 /// ``0..=255`` Rank Byte/Token Bijection Table
@@ -48,7 +59,8 @@ impl<T: TokenType> ByteMapVocab<T> {
     /// Build a `ByteTable` from a byte-ord => token table.
     ///
     /// ## Arguments
-    /// * `byte_to_token` - A slice of tokens where the index corresponds to the byte value.
+    /// * `byte_to_token` - A slice of tokens where the index corresponds to the
+    ///   byte value.
     ///
     /// ## Returns
     /// A new `ByteMapVocab` instance.
@@ -201,7 +213,10 @@ impl<T: TokenType> VocabIndex<T> for ByteMapVocab<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{alloc::format, vocab::utility::testing::build_test_shift_byte_vocab};
+    use crate::{
+        alloc::format,
+        vocab::utility::testing::build_test_shift_byte_vocab,
+    };
 
     #[test]
     fn test_byte_vocab_default() {

--- a/crates/wordchipper/src/vocab/io/base64_vocab.rs
+++ b/crates/wordchipper/src/vocab/io/base64_vocab.rs
@@ -2,11 +2,19 @@
 
 use std::{
     fs::File,
-    io::{BufRead, BufReader, BufWriter, Write},
+    io::{
+        BufRead,
+        BufReader,
+        BufWriter,
+        Write,
+    },
     path::Path,
 };
 
-use base64::{Engine, prelude::BASE64_STANDARD};
+use base64::{
+    Engine,
+    prelude::BASE64_STANDARD,
+};
 
 use crate::{
     TokenType,
@@ -14,7 +22,11 @@ use crate::{
     WCResult,
     prelude::*,
     spanners::TextSpanningConfig,
-    vocab::{SpanMapVocab, UnifiedTokenVocab, vocab_types::SpanTokenMap},
+    vocab::{
+        SpanMapVocab,
+        UnifiedTokenVocab,
+        vocab_types::SpanTokenMap,
+    },
 };
 
 /// Build a [`UnifiedTokenVocab`] from a pretrained bas64 vocab file.

--- a/crates/wordchipper/src/vocab/io/datagym_vocab.rs
+++ b/crates/wordchipper/src/vocab/io/datagym_vocab.rs
@@ -1,6 +1,9 @@
 //! # `DataGym` Vocabulary
 
-use std::io::{BufRead, BufReader};
+use std::io::{
+    BufRead,
+    BufReader,
+};
 
 use serde_json::Value;
 
@@ -11,10 +14,16 @@ use crate::{
     prelude::*,
     pretrained::openai::{
         oa_r50k_base_spanning_config,
-        resources::{OA_GPT2_ENCODER_JSON_KEYED_RESOURCE, OA_GPT2_VOCAB_BPE_KEYED_RESOURCE},
+        resources::{
+            OA_GPT2_ENCODER_JSON_KEYED_RESOURCE,
+            OA_GPT2_VOCAB_BPE_KEYED_RESOURCE,
+        },
     },
     support::resources::ResourceLoader,
-    vocab::{SpanMapVocab, SpanTokenMap},
+    vocab::{
+        SpanMapVocab,
+        SpanTokenMap,
+    },
 };
 
 /// A map from mojibake characters to their byte representation.
@@ -41,7 +50,8 @@ impl MojibakeDecoder for MojibakeMap {
     }
 }
 
-/// Builds the default byte vocabulary and mojibake map for datagym vocabularies.
+/// Builds the default byte vocabulary and mojibake map for datagym
+/// vocabularies.
 ///
 /// Datagym was encoded using ISO/IEC 8859-1; and so the [`MojibakeMap`] is used
 /// to translate scrambled ("mojibake") UTF-8 decoded characters into the
@@ -131,8 +141,8 @@ where
     R: BufRead,
 {
     // check that the encoder file matches the merges file
-    // this sanity check is important since tiktoken assumes that ranks are ordered the same
-    // as merge priority
+    // this sanity check is important since tiktoken assumes that ranks are ordered
+    // the same as merge priority
     let encoder_json: Value = serde_json::from_reader(encoder_json_reader)
         .unwrap_or(Value::Object(serde_json::Map::default()));
     let mut encoder_json_loaded: SpanTokenMap<usize> = encoder_json
@@ -200,12 +210,19 @@ pub fn load_gpt2_vocab<T: TokenType>(
 
 #[cfg(test)]
 mod tests {
-    use std::{println, sync::Arc};
+    use std::{
+        println,
+        sync::Arc,
+    };
 
     use wordchipper_disk_cache::WordchipperDiskCache;
 
     use super::*;
-    use crate::{TokenEncoderOptions, UnifiedTokenVocab, encoders::testing::common_encoder_tests};
+    use crate::{
+        TokenEncoderOptions,
+        UnifiedTokenVocab,
+        encoders::testing::common_encoder_tests,
+    };
 
     #[test]
     #[cfg(all(feature = "std", feature = "datagym", feature = "download"))]

--- a/crates/wordchipper/src/vocab/io/mod.rs
+++ b/crates/wordchipper/src/vocab/io/mod.rs
@@ -15,12 +15,13 @@
 //! };
 //!
 //! fn example() -> wordchipper::WCResult<Arc<Tokenizer<u32>>> {
-//!     let vocab: Arc<UnifiedTokenVocab<u32>> = load_base64_unified_vocab_path(
-//!         "vocab.tiktoken",
-//!         TextSpanningConfig::from_pattern(OA_O200K_BASE_PATTERN),
-//!     )
-//!     .expect("failed to load vocab")
-//!     .into();
+//!     let vocab: Arc<UnifiedTokenVocab<u32>> =
+//!         load_base64_unified_vocab_path(
+//!             "vocab.tiktoken",
+//!             TextSpanningConfig::from_pattern(OA_O200K_BASE_PATTERN),
+//!         )
+//!         .expect("failed to load vocab")
+//!         .into();
 //!
 //!     let tokenizer: Arc<Tokenizer<u32>> =
 //!         TokenizerOptions::default().with_parallel(true).build(vocab);

--- a/crates/wordchipper/src/vocab/mod.rs
+++ b/crates/wordchipper/src/vocab/mod.rs
@@ -15,12 +15,13 @@
 //! * [`ByteMapVocab`] - bidirectional byte⟷token mapping
 //! * [`PairMapVocab`] - BPE merge pair mapping: `(T, T) → T`
 //! * [`SpanMapVocab`] - span dictionary mapping: `Vec<u8> → T`
-//! * [`crate::spanners::TextSpanningConfig`] - text spanners configuration
-//!   that defines how text is split into spans for encoding, including
-//!   special token words
+//! * [`crate::spanners::TextSpanningConfig`] - text spanners configuration that
+//!   defines how text is split into spans for encoding, including special token
+//!   words
 //!
 //! Pre-trained vocabulary loaders return [`UnifiedTokenVocab<T>`] instances,
-//! which can be converted between [`crate::TokenType`]s via [`UnifiedTokenVocab::to_token_type`].
+//! which can be converted between [`crate::TokenType`]s via
+//! [`UnifiedTokenVocab::to_token_type`].
 //!
 //! ## Loading and Saving Models
 //!

--- a/crates/wordchipper/src/vocab/pair_vocab.rs
+++ b/crates/wordchipper/src/vocab/pair_vocab.rs
@@ -3,9 +3,21 @@
 use crate::{
     WCResult,
     alloc::vec::Vec,
-    decoders::{TokenDecoder, utility::PairExpansionDecoder},
-    types::{Pair, TokenType, WCHashSet},
-    vocab::{ByteMapVocab, PairTokenMap, VocabIndex, utility::validators::try_vocab_size},
+    decoders::{
+        TokenDecoder,
+        utility::PairExpansionDecoder,
+    },
+    types::{
+        Pair,
+        TokenType,
+        WCHashSet,
+    },
+    vocab::{
+        ByteMapVocab,
+        PairTokenMap,
+        VocabIndex,
+        utility::validators::try_vocab_size,
+    },
 };
 
 /// Validate that a [`ByteMapVocab`] and [`PairTokenMap`] are compatible.
@@ -169,7 +181,10 @@ impl<T: TokenType> VocabIndex<T> for PairMapVocab<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vocab::{ByteMapVocab, PairTokenMap};
+    use crate::vocab::{
+        ByteMapVocab,
+        PairTokenMap,
+    };
 
     #[test]
     fn test_tokens_sorted() {

--- a/crates/wordchipper/src/vocab/span_vocab.rs
+++ b/crates/wordchipper/src/vocab/span_vocab.rs
@@ -3,7 +3,11 @@
 use crate::{
     WCResult,
     alloc::vec::Vec,
-    types::{TokenType, WCHashMap, WCHashSet},
+    types::{
+        TokenType,
+        WCHashMap,
+        WCHashSet,
+    },
     vocab::{
         ByteMapVocab,
         ByteTokenMap,
@@ -276,7 +280,11 @@ impl<T: TokenType> VocabIndex<T> for SpanMapVocab<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vocab::{ByteMapVocab, SpanTokenMap, VocabIndex};
+    use crate::vocab::{
+        ByteMapVocab,
+        SpanTokenMap,
+        VocabIndex,
+    };
 
     #[test]
     fn test_access() {

--- a/crates/wordchipper/src/vocab/special_vocab.rs
+++ b/crates/wordchipper/src/vocab/special_vocab.rs
@@ -4,11 +4,21 @@ use crate::{
     WCResult,
     alloc::vec::Vec,
     support::{
-        regex::{RegexPattern, alternate_choice_regex_pattern},
+        regex::{
+            RegexPattern,
+            alternate_choice_regex_pattern,
+        },
         strings::string_from_utf8_lossy,
     },
-    types::{TokenType, WCHashSet},
-    vocab::{SpanTokenMap, VocabIndex, utility::validators::try_vocab_size},
+    types::{
+        TokenType,
+        WCHashSet,
+    },
+    vocab::{
+        SpanTokenMap,
+        VocabIndex,
+        utility::validators::try_vocab_size,
+    },
 };
 
 /// Token vocabulary for special words.
@@ -108,7 +118,8 @@ impl<T: TokenType> SpecialVocab<T> {
     /// * `chunk` - The byte slice to look up.
     ///
     /// ## Returns
-    /// An `Option` containing the token if the span exists in the special vocabulary.
+    /// An `Option` containing the token if the span exists in the special
+    /// vocabulary.
     pub fn lookup_token(
         &self,
         chunk: &[u8],

--- a/crates/wordchipper/src/vocab/token_vocab.rs
+++ b/crates/wordchipper/src/vocab/token_vocab.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     alloc::vec::Vec,
-    types::{TokenType, WCHashSet},
+    types::{
+        TokenType,
+        WCHashSet,
+    },
 };
 
 /// Common traits for token vocabularies.

--- a/crates/wordchipper/src/vocab/unified_vocab.rs
+++ b/crates/wordchipper/src/vocab/unified_vocab.rs
@@ -20,25 +20,28 @@ use crate::{
     },
 };
 
-/// A unified vocabulary structure for BPE tokenization that provides coherent views
-/// of vocabulary components through multiple mapping interfaces.
+/// A unified vocabulary structure for BPE tokenization that provides coherent
+/// views of vocabulary components through multiple mapping interfaces.
 ///
 /// # Overview
 ///
-/// [`UnifiedTokenVocab<T>`] is the primary user-facing vocabulary type, generic over
-/// `T: TokenType` (unsigned integer types like `u16`, `u32`, `u64`). It provides
-/// several complementary views of the same vocabulary data:
+/// [`UnifiedTokenVocab<T>`] is the primary user-facing vocabulary type, generic
+/// over `T: TokenType` (unsigned integer types like `u16`, `u32`, `u64`). It
+/// provides several complementary views of the same vocabulary data:
 ///
 /// * [`ByteMapVocab`] - Bijective `u8 ↔ T` byte-to-token mapping (256 entries)
-/// * [`SpanMapVocab`] - Dictionary mapping `Vec<u8> → T` for multi-byte sequences
+/// * [`SpanMapVocab`] - Dictionary mapping `Vec<u8> → T` for multi-byte
+///   sequences
 /// * [`PairMapVocab`] - BPE merge rules mapping `(T, T) → T` for token pairs
-/// * [`TextSpanningConfig`] - Text segmentation rules (regex patterns, special tokens)
+/// * [`TextSpanningConfig`] - Text segmentation rules (regex patterns, special
+///   tokens)
 ///
 /// # Typical Usage
 ///
 /// Pre-trained vocabulary loaders return `UnifiedTokenVocab<T>`, which can be
 /// accessed via `Arc<UnifiedTokenVocab<T>>`:
-/// - Converted to different token types via [`to_token_type`](Self::to_token_type)
+/// - Converted to different token types via
+///   [`to_token_type`](Self::to_token_type)
 ///
 /// # Example
 ///
@@ -143,9 +146,11 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
         })
     }
 
-    /// Create a copy of this [`UnifiedTokenVocab`] with a different [`TokenType`].
+    /// Create a copy of this [`UnifiedTokenVocab`] with a different
+    /// [`TokenType`].
     ///
-    /// This will fail if the maximum token index for the new token type is exceeded.
+    /// This will fail if the maximum token index for the new token type is
+    /// exceeded.
     pub fn to_token_type<G: TokenType>(&self) -> WCResult<UnifiedTokenVocab<G>> {
         Ok(UnifiedTokenVocab::<G> {
             spanning: self.spanning.to_token_type::<G>()?,
@@ -214,12 +219,13 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
     /// Looks up a token in the vocabulary using the provided byte slice.
     ///
     /// ## Arguments
-    /// * `span` - A byte slice (`&[u8]`) representing the token to be looked up in the vocabulary.
+    /// * `span` - A byte slice (`&[u8]`) representing the token to be looked up
+    ///   in the vocabulary.
     ///
     /// ## Returns
-    /// * `Option<T>` - Returns `Some(T)` if the token is found in the vocabulary,
-    ///   where `T` is the type of the value associated with the token. Returns
-    ///   `None` if the token is not found.
+    /// * `Option<T>` - Returns `Some(T)` if the token is found in the
+    ///   vocabulary, where `T` is the type of the value associated with the
+    ///   token. Returns `None` if the token is not found.
     pub fn lookup_token(
         &self,
         span: &[u8],
@@ -227,13 +233,16 @@ impl<T: TokenType> UnifiedTokenVocab<T> {
         self.span_vocab.lookup_token(span)
     }
 
-    /// Looks up a given pair in the pair vocabulary and retrieves its associated data, if present.
+    /// Looks up a given pair in the pair vocabulary and retrieves its
+    /// associated data, if present.
     ///
     /// ## Arguments
-    /// * `pair` - A reference to the `Pair<T>` to be looked up in the pair vocabulary.
+    /// * `pair` - A reference to the `Pair<T>` to be looked up in the pair
+    ///   vocabulary.
     ///
     /// ## Returns
-    /// * `Option<&T>` - Returns `Some(&T)` if the pair is found in the pair vocabulary, otherwise returns `None`.
+    /// * `Option<&T>` - Returns `Some(&T)` if the pair is found in the pair
+    ///   vocabulary, otherwise returns `None`.
     pub fn lookup_pair(
         &self,
         pair: &Pair<T>,
@@ -269,7 +278,10 @@ mod tests {
     use super::*;
     use crate::{
         spanners::TextSpanningConfig,
-        vocab::{PairTokenMap, SpanMapVocab},
+        vocab::{
+            PairTokenMap,
+            SpanMapVocab,
+        },
     };
 
     #[test]

--- a/crates/wordchipper/src/vocab/utility/factories.rs
+++ b/crates/wordchipper/src/vocab/utility/factories.rs
@@ -1,11 +1,15 @@
 //! # Vocab Factory Support
 
 #[cfg(feature = "std")]
-use std::{
-    fs::File,
-    io::{BufRead, BufReader},
-    path::{Path, PathBuf},
-};
+use std::fs::File;
+#[cfg(feature = "std")]
+use std::io::BufRead;
+#[cfg(feature = "std")]
+use std::io::BufReader;
+#[cfg(feature = "std")]
+use std::path::Path;
+#[cfg(feature = "std")]
+use std::path::PathBuf;
 
 #[cfg(feature = "std")]
 use crate::WCResult;
@@ -15,10 +19,16 @@ use crate::support::resources::ResourceLoader;
 use crate::vocab::UnifiedTokenVocab;
 use crate::{
     TokenType,
-    alloc::{string::String, vec::Vec},
+    alloc::{
+        string::String,
+        vec::Vec,
+    },
     spanners::TextSpanningConfig,
     support::{
-        regex::{ConstRegexPattern, RegexPattern},
+        regex::{
+            ConstRegexPattern,
+            RegexPattern,
+        },
         resources::ConstKeyedResource,
     },
 };

--- a/crates/wordchipper/src/vocab/utility/mod.rs
+++ b/crates/wordchipper/src/vocab/utility/mod.rs
@@ -9,6 +9,8 @@ pub mod testing;
 pub mod validators;
 
 #[doc(inline)]
-pub use specials_tools::{format_carrot, format_reserved_carrot};
+pub use specials_tools::format_carrot;
+#[doc(inline)]
+pub use specials_tools::format_reserved_carrot;
 #[doc(inline)]
 pub use token_list::*;

--- a/crates/wordchipper/src/vocab/utility/pattern_tools.rs
+++ b/crates/wordchipper/src/vocab/utility/pattern_tools.rs
@@ -22,9 +22,11 @@
 ///
 /// # Parameters
 ///
-/// - `$sep`: A string literal used as a separator between the provided string literals.
-/// - `($first $(, $rest)*)`: A tuple of at least one string literal. The first string literal
-///   is mandatory, and the rest are optional. A trailing comma is allowed but not required.
+/// - `$sep`: A string literal used as a separator between the provided string
+///   literals.
+/// - `($first $(, $rest)*)`: A tuple of at least one string literal. The first
+///   string literal is mandatory, and the rest are optional. A trailing comma
+///   is allowed but not required.
 #[macro_export]
 macro_rules! join_strs {
     ($sep:literal, ($first:literal $(, $rest:literal)* $(,)?)) => {

--- a/crates/wordchipper/src/vocab/utility/specials_tools.rs
+++ b/crates/wordchipper/src/vocab/utility/specials_tools.rs
@@ -1,6 +1,9 @@
 //! # Special Tokens Tools
 
-use crate::alloc::{format, string::String};
+use crate::alloc::{
+    format,
+    string::String,
+};
 
 /// Generate a "<|$name|>" string literal.
 #[macro_export]

--- a/crates/wordchipper/src/vocab/utility/testing/mod.rs
+++ b/crates/wordchipper/src/vocab/utility/testing/mod.rs
@@ -4,7 +4,12 @@ use crate::{
     TokenType,
     alloc::vec::Vec,
     spanners::TextSpanningConfig,
-    vocab::{ByteMapVocab, SpanMapVocab, SpanTokenMap, UnifiedTokenVocab},
+    vocab::{
+        ByteMapVocab,
+        SpanMapVocab,
+        SpanTokenMap,
+        UnifiedTokenVocab,
+    },
 };
 
 /// Create a test [`UnifiedTokenVocab`].

--- a/crates/wordchipper/src/vocab/utility/token_list.rs
+++ b/crates/wordchipper/src/vocab/utility/token_list.rs
@@ -3,7 +3,10 @@
 use crate::{
     TokenType,
     alloc::{
-        string::{String, ToString},
+        string::{
+            String,
+            ToString,
+        },
         vec::Vec,
     },
 };

--- a/crates/wordchipper/src/vocab/utility/validators.rs
+++ b/crates/wordchipper/src/vocab/utility/validators.rs
@@ -1,10 +1,15 @@
 //! Validators for various configuration options.
-use crate::{TokenType, WCError, WCResult};
+use crate::{
+    TokenType,
+    WCError,
+    WCResult,
+};
 
 /// The size of the u8 space.
 pub const U8_SIZE: usize = u8::MAX as usize + 1;
 
-/// Validates and returns the vocabulary size, ensuring it's at least the size of the u8 space.
+/// Validates and returns the vocabulary size, ensuring it's at least the size
+/// of the u8 space.
 pub fn try_vocab_size<T: TokenType>(vocab_size: usize) -> WCResult<usize> {
     if T::from_usize(vocab_size - 1).is_none() {
         Err(WCError::VocabSizeOverflow { size: vocab_size })

--- a/crates/wordchipper/src/vocab/vocab_types.rs
+++ b/crates/wordchipper/src/vocab/vocab_types.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     alloc::vec::Vec,
-    types::{Pair, WCHashMap},
+    types::{
+        Pair,
+        WCHashMap,
+    },
 };
 
 /// `{ Pair<T> -> T}` map.

--- a/dev-crates/sample-timer/src/batch_stats.rs
+++ b/dev-crates/sample-timer/src/batch_stats.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    time::Duration,
+};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct EngineBatchTimes {

--- a/dev-crates/sample-timer/src/main.rs
+++ b/dev-crates/sample-timer/src/main.rs
@@ -1,7 +1,10 @@
 extern crate core;
 
 use std::{
-    fmt::{Display, Formatter},
+    fmt::{
+        Display,
+        Formatter,
+    },
     io,
     io::IsTerminal,
     iter::Iterator,
@@ -9,14 +12,29 @@ use std::{
     time::Duration,
 };
 
-use arrow::array::{Array, StringArray};
-use batch_stats::{BatchStats, EngineBatchTimes};
-use clap::{Parser, ValueEnum};
-use engines::{BoxError, EncDecEngine};
+use arrow::array::{
+    Array,
+    StringArray,
+};
+use batch_stats::{
+    BatchStats,
+    EngineBatchTimes,
+};
+use clap::{
+    Parser,
+    ValueEnum,
+};
+use engines::{
+    BoxError,
+    EncDecEngine,
+};
 use indicatif::ProgressBar;
 use rand::prelude::SliceRandom;
 use similar::TextDiff;
-use tiktoken_rs::{CoreBPE, Rank};
+use tiktoken_rs::{
+    CoreBPE,
+    Rank,
+};
 use tiktoken_support::TiktokenRsEngine;
 use wordchipper::{
     TokenEncoderOptions,
@@ -27,11 +45,17 @@ use wordchipper::{
     disk_cache::WordchipperDiskCache,
     pretrained::openai::OATokenizer,
     support::{
-        slices::{inner_slice_view, inner_str_view},
+        slices::{
+            inner_slice_view,
+            inner_str_view,
+        },
         timers::timeit,
     },
 };
-use wordchipper_data::dataset::{DatasetCache, DatasetCacheConfig};
+use wordchipper_data::dataset::{
+    DatasetCache,
+    DatasetCacheConfig,
+};
 use wordchipper_support::WordchipperEngine;
 
 mod engines;
@@ -43,7 +67,9 @@ mod wordchipper_support;
 #[cfg(feature = "tokenizers")]
 mod tokenizers_support;
 #[cfg(feature = "tokenizers")]
-use tokenizers_support::{TokenizersEngine, load_tokenizers_tok};
+use tokenizers_support::TokenizersEngine;
+#[cfg(feature = "tokenizers")]
+use tokenizers_support::load_tokenizers_tok;
 use wordchipper::spanners::span_lexers::accelerators::get_regex_accelerator;
 
 /// Wordchipper Encode/Decode Side-by-Side Benchmarks.
@@ -69,34 +95,34 @@ pub struct Args {
     pub model: ModelSelector,
 
     /// Ignore missing models?
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub ignore_missing: bool,
 
     /// Test against tiktoken-rs?
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub tiktoken: bool,
 
     #[cfg(feature = "tokenizers")]
     /// Test against HF tokenizers?
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub tokenizers: bool,
 
     /// Time decoding as well.
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long, num_args = 0..=1, default_value_t = false, default_missing_value = "true")]
     pub decode: bool,
 
     /// Validate encoders against each other, decoders against input.
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub validate: bool,
 
     /// Re-span text when verifying?
     /// Slower, but works around span configs which leave gaps in the text.
-    /* hack: 3-state boolean */
+    // hack: 3-state boolean
     #[arg(long,
     num_args = 0..=1,
     default_value_t = false,
@@ -196,7 +222,8 @@ fn main() -> Result<(), BoxError> {
     // println!("Loading wordchipper...");
     let (_desc, vocab) = wordchipper::load_vocab(args.model.to_string().as_str(), &mut disk_cache)?;
 
-    // TODO: complete batch-observer inversion of control for additional tokenizer wrappers.
+    // TODO: complete batch-observer inversion of control for additional tokenizer
+    // wrappers.
 
     let mut candidate_engines: Vec<Arc<dyn EncDecEngine<Rank>>> = Vec::new();
 

--- a/dev-crates/sample-timer/src/tiktoken_support.rs
+++ b/dev-crates/sample-timer/src/tiktoken_support.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
-use tiktoken_rs::{CoreBPE, Rank};
+use tiktoken_rs::{
+    CoreBPE,
+    Rank,
+};
 
-use crate::engines::{BoxError, EncDecEngine};
+use crate::engines::{
+    BoxError,
+    EncDecEngine,
+};
 
 /// [`EncDecEngine`] implementation for [`CoreBPE`].
 pub struct TiktokenRsEngine {

--- a/dev-crates/sample-timer/src/tokenizers_support.rs
+++ b/dev-crates/sample-timer/src/tokenizers_support.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
-use tokenizers::{Encoding, tokenizer::Tokenizer};
+use tokenizers::{
+    Encoding,
+    tokenizer::Tokenizer,
+};
 
-use crate::engines::{BoxError, EncDecEngine};
+use crate::engines::{
+    BoxError,
+    EncDecEngine,
+};
 
 /// [`EncDecEngine`] implementation for [`Tokenizer`].
 pub struct TokenizersEngine {

--- a/dev-crates/sample-timer/src/wordchipper_support.rs
+++ b/dev-crates/sample-timer/src/wordchipper_support.rs
@@ -1,8 +1,17 @@
 use std::sync::Arc;
 
-use wordchipper::{TokenDecoder, TokenEncoder, TokenType, Tokenizer, spanners::TextSpanner};
+use wordchipper::{
+    TokenDecoder,
+    TokenEncoder,
+    TokenType,
+    Tokenizer,
+    spanners::TextSpanner,
+};
 
-use crate::engines::{BoxError, EncDecEngine};
+use crate::engines::{
+    BoxError,
+    EncDecEngine,
+};
 
 /// [`EncDecEngine`] implementation for [`TokenEncoder`] + [`TokenDecoder`].
 pub struct WordchipperEngine<T: TokenType> {

--- a/dev-crates/wordchipper-bench/benches/decoding_single.rs
+++ b/dev-crates/wordchipper-bench/benches/decoding_single.rs
@@ -1,9 +1,19 @@
 #![allow(missing_docs)]
 
-use std::sync::{Arc, LazyLock};
+use std::sync::{
+    Arc,
+    LazyLock,
+};
 
-use divan::{Bencher, black_box, counter::BytesCount};
-use tiktoken_rs::{CoreBPE, Rank};
+use divan::{
+    Bencher,
+    black_box,
+    counter::BytesCount,
+};
+use tiktoken_rs::{
+    CoreBPE,
+    Rank,
+};
 use tokenizers::Tokenizer;
 use wordchipper::{
     TokenDecoder,

--- a/dev-crates/wordchipper-bench/benches/encoding_parallel.rs
+++ b/dev-crates/wordchipper-bench/benches/encoding_parallel.rs
@@ -3,7 +3,11 @@
 use std::sync::LazyLock;
 
 use arrow::array::Array;
-use divan::{Bencher, black_box, counter::BytesCount};
+use divan::{
+    Bencher,
+    black_box,
+    counter::BytesCount,
+};
 use wordchipper_data::dataset::DatasetCacheConfig;
 
 #[global_allocator]
@@ -67,8 +71,15 @@ fn load_batch() -> Batch {
 static BATCH: LazyLock<Batch> = LazyLock::new(load_batch);
 
 mod wordchipper {
-    use ::wordchipper::{TokenEncoderOptions, encoders::token_span_encoder::SpanEncoderSelector};
-    use wordchipper_bench::{OA_CL100K_BASE, OA_O200K_BASE, OA_R50K_BASE};
+    use ::wordchipper::{
+        TokenEncoderOptions,
+        encoders::token_span_encoder::SpanEncoderSelector,
+    };
+    use wordchipper_bench::{
+        OA_CL100K_BASE,
+        OA_O200K_BASE,
+        OA_R50K_BASE,
+    };
 
     use super::*;
 
@@ -366,7 +377,12 @@ mod wordchipper {
 
 mod tiktoken {
     use rayon::prelude::*;
-    use tiktoken_rs::{CoreBPE, cl100k_base, o200k_base, r50k_base};
+    use tiktoken_rs::{
+        CoreBPE,
+        cl100k_base,
+        o200k_base,
+        r50k_base,
+    };
 
     use super::*;
 
@@ -401,7 +417,10 @@ mod tiktoken {
 }
 
 mod tokenizers {
-    use wordchipper_bench::{HF_CL100K, HF_O200K};
+    use wordchipper_bench::{
+        HF_CL100K,
+        HF_O200K,
+    };
 
     use super::*;
 

--- a/dev-crates/wordchipper-bench/benches/encoding_single.rs
+++ b/dev-crates/wordchipper-bench/benches/encoding_single.rs
@@ -1,8 +1,21 @@
 #![allow(missing_docs)]
 
-use divan::{Bencher, black_box, counter::BytesCount};
-use wordchipper::{TokenEncoderOptions, encoders::token_span_encoder::SpanEncoderSelector};
-use wordchipper_bench::{HF_CL100K, HF_O200K, OA_CL100K_BASE, OA_O200K_BASE, OA_R50K_BASE};
+use divan::{
+    Bencher,
+    black_box,
+    counter::BytesCount,
+};
+use wordchipper::{
+    TokenEncoderOptions,
+    encoders::token_span_encoder::SpanEncoderSelector,
+};
+use wordchipper_bench::{
+    HF_CL100K,
+    HF_O200K,
+    OA_CL100K_BASE,
+    OA_O200K_BASE,
+    OA_R50K_BASE,
+};
 
 #[global_allocator]
 static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();

--- a/dev-crates/wordchipper-bench/benches/spanning.rs
+++ b/dev-crates/wordchipper-bench/benches/spanning.rs
@@ -2,14 +2,25 @@
 
 use std::sync::Arc;
 
-use divan::{Bencher, black_box, counter::BytesCount};
+use divan::{
+    Bencher,
+    black_box,
+    counter::BytesCount,
+};
 use wordchipper::{
-    pretrained::openai::{OA_CL100K_BASE_PATTERN, OA_O200K_BASE_PATTERN, OA_R50K_BASE_PATTERN},
+    pretrained::openai::{
+        OA_CL100K_BASE_PATTERN,
+        OA_O200K_BASE_PATTERN,
+        OA_R50K_BASE_PATTERN,
+    },
     spanners::{
         TextSpanner,
         TextSpannerBuilder,
         TextSpanningConfig,
-        span_lexers::{LexerTextSpanner, SpanLexer},
+        span_lexers::{
+            LexerTextSpanner,
+            SpanLexer,
+        },
     },
     support::regex::RegexWrapper,
 };

--- a/dev-crates/wordchipper-bench/src/bin/bench_json.rs
+++ b/dev-crates/wordchipper-bench/src/bin/bench_json.rs
@@ -1,8 +1,15 @@
 //! Run `cargo bench` and convert divan output to JSON.
 
 use std::{
-    io::{BufRead, BufReader, Write},
-    process::{Command, Stdio},
+    io::{
+        BufRead,
+        BufReader,
+        Write,
+    },
+    process::{
+        Command,
+        Stdio,
+    },
     sync::Mutex,
     thread,
 };

--- a/dev-crates/wordchipper-bench/src/divan_parser.rs
+++ b/dev-crates/wordchipper-bench/src/divan_parser.rs
@@ -1,7 +1,8 @@
 //! Parse divan benchmark output into structured results.
 //!
 //! Divan has no machine-readable output format. This module parses the
-//! human-readable table output line by line and produces [`BenchResult`] values.
+//! human-readable table output line by line and produces [`BenchResult`]
+//! values.
 
 use std::collections::BTreeMap;
 
@@ -272,7 +273,8 @@ const TIME_NS: &[(&str, f64)] = &[
     ("s", 1e9),
 ];
 
-/// Byte size unit to bytes (also used for throughput by stripping the "/s" suffix).
+/// Byte size unit to bytes (also used for throughput by stripping the "/s"
+/// suffix).
 const BYTE_UNITS: &[(&str, f64)] = &[
     ("", 1.0),
     ("B", 1.0),
@@ -373,14 +375,15 @@ fn table_lookup(
     table.iter().find(|&&(u, _)| u == unit).map(|&(_, m)| m)
 }
 
-/// Look up a throughput unit (e.g. "MB/s") by stripping "/s" and checking byte units.
+/// Look up a throughput unit (e.g. "MB/s") by stripping "/s" and checking byte
+/// units.
 fn throughput_lookup(unit: &str) -> Option<f64> {
     unit.strip_suffix("/s")
         .and_then(|b| table_lookup(b, BYTE_UNITS))
 }
 
-/// Build [`StatValues`] from raw parsed values, using a lookup function for unit conversion.
-/// Returns `None` if no values matched.
+/// Build [`StatValues`] from raw parsed values, using a lookup function for
+/// unit conversion. Returns `None` if no values matched.
 fn convert_row(
     row: &[Option<(f64, String)>; 4],
     lookup: impl Fn(&str) -> Option<f64>,

--- a/dev-crates/wordchipper-bench/src/lib.rs
+++ b/dev-crates/wordchipper-bench/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod divan_parser;
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{
+    Arc,
+    Mutex,
+    OnceLock,
+};
 
 use wordchipper::{
     TokenEncoder,

--- a/dev-crates/wordchipper-data/src/dataset.rs
+++ b/dev-crates/wordchipper-data/src/dataset.rs
@@ -1,9 +1,19 @@
 //! # Nanochat Dataset Loader
 
-use std::{fs, fs::File, path::PathBuf};
+use std::{
+    fs,
+    fs::File,
+    path::PathBuf,
+};
 
-use downloader::{Download, Downloader};
-use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
+use downloader::{
+    Download,
+    Downloader,
+};
+use parquet::arrow::arrow_reader::{
+    ParquetRecordBatchReader,
+    ParquetRecordBatchReaderBuilder,
+};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -55,8 +65,8 @@ impl DatasetSource {
 
     /// Construct a shard filename.
     ///
-    /// Substitutes the ``Self::format_index(index)`` result in for `"{index}"` in
-    /// the [`Self::shard_template`].
+    /// Substitutes the ``Self::format_index(index)`` result in for `"{index}"`
+    /// in the [`Self::shard_template`].
     pub fn format_shard_filename(
         &self,
         index: usize,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,11 +1,30 @@
-edition = "2024"
-
-fn_params_layout = "Vertical"
-format_code_in_doc_comments = true
-format_macro_matchers = true
-group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
-imports_layout = "HorizontalVertical"
-newline_style = "Unix"
-reorder_impl_items = true
+# These configs require `cargo +nightly fmt` to work.
 unstable_features = true
+edition = "2024"
+style_edition = "2024"
+
+newline_style = "Unix"
+
+# We insist on vertical layout for several reasons:
+# - it is a uniform style to read
+# - it is the most diff-friendly style
+fn_params_layout = "Vertical"
+
+normalize_comments = true
+format_macro_matchers = true
+
+reorder_impl_items = true
+use_field_init_shorthand = true
+
+wrap_comments = true
+
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 80
+
+# Give a hint about deps in the grouping.
+group_imports = "StdExternalCrate"
+# We still get cargo grouping, but the vert style is more diff-friendly.
+# Maximum diff-friendly would be "Item", but it is not as readable.
+imports_granularity = "Crate"
+# Again, using vertical layout for diff-friendlyness.
+imports_layout = "Vertical"


### PR DESCRIPTION
- Updated `rustfmt` settings to enforce stricter code formatting norms.
- Adjusted imports to follow a vertical layout.
