### PR TITLE
Always rebuild WASM in book setup script

### DIFF
--- a/book/setup-wasm.sh
+++ b/book/setup-wasm.sh
@@ -7,11 +7,9 @@ REPO_ROOT="$(cd "$DIR/.." && pwd)"
 PKG="$REPO_ROOT/bindings/wasm/pkg"
 DEST="$DIR/src/wasm"
 
-# 1. Build WASM if needed.
-if [ ! -f "$PKG/wordchipper_wasm.js" ]; then
-  echo "Building WASM package..."
-  wasm-pack build "$REPO_ROOT/bindings/wasm" --target web
-fi
+# 1. Build WASM (cargo/wasm-pack will skip if unchanged).
+echo "Building WASM package..."
+wasm-pack build "$REPO_ROOT/bindings/wasm" --target web
 
 # 2. Copy WASM artifacts.
 mkdir -p "$DEST"


### PR DESCRIPTION
## Summary
- Remove the file-existence guard in `book/setup-wasm.sh` so `wasm-pack build` runs unconditionally
- Cargo/wasm-pack incremental compilation makes this free when nothing changed, but correctly picks up source changes the old `if [ ! -f ... ]` check would miss

## Test plan
- [x] Run `book/setup-wasm.sh` and verify WASM is built and copied
- [x] Run it again and verify it completes quickly (incremental no-op)