### PR TITLE
Update `.iml` and refactor lexer initialization

### DIFF
--- a/.idea/wordchipper.iml
+++ b/.idea/wordchipper.iml
@@ -32,6 +32,8 @@
       <sourceFolder url="file://$MODULE_DIR$/crates/wordchipper-training/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/wordchipper-training/examples/training-demo/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/crates/wchipper/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/dev-crates/lexer-equivalence/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/dev-crates/lexer-equivalence/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/crates/nanochat/target" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/crates/wordchipper/target" />

--- a/dev-crates/sample-timer/src/main.rs
+++ b/dev-crates/sample-timer/src/main.rs
@@ -207,7 +207,6 @@ fn main() -> Result<(), BoxError> {
     // println!("Loading wordchipper...");
     let loaded = wordchipper::load_vocab(args.model.to_string().as_str(), &mut disk_cache)?;
 
-    println!("Loaded: {:?}", loaded.description());
     let vocab = loaded.vocab().clone();
 
     // TODO: complete batch-observer inversion of control for additional tokenizer
@@ -216,7 +215,7 @@ fn main() -> Result<(), BoxError> {
     let mut candidate_engines: Vec<Arc<dyn EncDecEngine<Rank>>> = Vec::new();
 
     let wc_engine = Arc::new(WordchipperEngine::<Rank>::new(
-        args.model.to_string(),
+        loaded.description().id().to_string(),
         TokenizerOptions::default()
             .with_parallel(true)
             .with_accelerated_lexers(false)
@@ -231,7 +230,7 @@ fn main() -> Result<(), BoxError> {
             .build(vocab.clone());
 
         candidate_engines.push(Arc::new(WordchipperEngine::<Rank>::new(
-            format!("{}/accel", args.model),
+            format!("{}/accel", loaded.description().id(),),
             Tokenizer::new(
                 vocab.clone(),
                 encoder,


### PR DESCRIPTION
- Updated `.iml` file to include new source and test directories for `lexer-equivalence`.
- Refactored `sample-timer` to initialize engines using `vocab.description().id()` for improved clarity and efficiency.