### PR TITLE
Add modular parallel benchmark data support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,6 +2140,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,6 +2527,7 @@ dependencies = [
  "divan-parser",
  "humansize",
  "log",
+ "plotters",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ js-sys = "0.3"
 parquet = "58.0.0"
 proptest = "1.10.0"
 pyo3 = "0.28.2"
-plotters = "0.3.7"
+plotters = { version = "0.3.7", default-features = false }
 range-parser = "0.1.2"
 serial_test = "3.4.0"
 similar = "2.7.0"

--- a/dev-crates/report-tool/Cargo.toml
+++ b/dev-crates/report-tool/Cargo.toml
@@ -16,7 +16,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 humansize = { workspace = true }
 # fontlib issues, investigate wasm install.
-# plotters = { workspace = true }
+plotters = { workspace = true, features = [
+    "svg_backend", "full_palette", "all_series", "all_elements"
+] }
 clap = { workspace = true, features = ["derive"] }
 regex = { workspace = true }
 log = { workspace = true }

--- a/dev-crates/report-tool/src/commands/dev_cmd.rs
+++ b/dev-crates/report-tool/src/commands/dev_cmd.rs
@@ -1,11 +1,8 @@
-use std::{
-    collections::HashMap,
-    path::Path,
-};
+use std::path::Path;
 
-use divan_parser::BenchResult;
-use regex::Regex;
 use wordchipper_cli_util::logging::LogArgs;
+
+use crate::util::bench_data::par_bench::ParBenchData;
 
 /// Args for the cat command.
 #[derive(clap::Args, Debug)]
@@ -27,37 +24,11 @@ impl DevArgs {
 
         let data_dir = Path::new(&self.data_dir);
 
-        let _data = load_parallel_data(data_dir.join("parallel"))?;
+        let data = ParBenchData::load_data(data_dir.join("parallel"))?;
+
+        println!("threads: {:?}", data.threads());
+        println!("series: {:#?}", data.series_names());
 
         Ok(())
     }
-}
-
-fn load_parallel_data<P: AsRef<Path>>(
-    dir: P
-) -> Result<HashMap<u32, Vec<BenchResult>>, Box<dyn std::error::Error>> {
-    let dir = dir.as_ref();
-
-    let pattern = r"^encoding_parallel\.(?<threads>\d+)\.json$";
-    let re = Regex::new(pattern)?;
-
-    let mut res: HashMap<u32, Vec<BenchResult>> = Default::default();
-
-    for entry in dir.read_dir()?.filter_map(Result::ok) {
-        let filename = entry.file_name().to_string_lossy().to_string();
-
-        if let Some(caps) = re.captures(&filename) {
-            let threads = caps.name("threads").unwrap().as_str().parse::<u32>()?;
-
-            let file = std::fs::File::open(entry.path())?;
-            let reader = std::io::BufReader::new(file);
-            let data = serde_json::from_reader(reader)?;
-
-            log::info!("threads: {}", threads);
-
-            res.insert(threads, data);
-        }
-    }
-
-    Ok(res)
 }

--- a/dev-crates/report-tool/src/main.rs
+++ b/dev-crates/report-tool/src/main.rs
@@ -234,6 +234,7 @@
 //
 
 pub mod commands;
+pub mod util;
 
 use clap::Parser;
 

--- a/dev-crates/report-tool/src/util/bench_data/mod.rs
+++ b/dev-crates/report-tool/src/util/bench_data/mod.rs
@@ -1,0 +1,1 @@
+pub mod par_bench;

--- a/dev-crates/report-tool/src/util/bench_data/par_bench.rs
+++ b/dev-crates/report-tool/src/util/bench_data/par_bench.rs
@@ -1,0 +1,79 @@
+use std::{
+    collections::{
+        BTreeMap,
+        BTreeSet,
+    },
+    path::Path,
+};
+
+use divan_parser::BenchResult;
+use regex::Regex;
+
+pub struct ParBenchData {
+    pub data: BTreeMap<u32, Vec<BenchResult>>,
+}
+
+impl ParBenchData {
+    pub fn new(data: BTreeMap<u32, Vec<BenchResult>>) -> Self {
+        Self { data }
+    }
+
+    pub fn load_data<P: AsRef<Path>>(dir: P) -> Result<Self, Box<dyn std::error::Error>> {
+        let dir = dir.as_ref();
+        log::info!("Loading ParBenchData from: {}", dir.display());
+
+        let pattern = r"^encoding_parallel\.(?<threads>\d+)\.json$";
+        let re = Regex::new(pattern)?;
+
+        let mut res: BTreeMap<u32, Vec<BenchResult>> = Default::default();
+
+        for entry in dir.read_dir()?.filter_map(Result::ok) {
+            let filename = entry.file_name().to_string_lossy().to_string();
+            if let Some(caps) = re.captures(&filename) {
+                let threads = caps.name("threads").unwrap().as_str().parse::<u32>()?;
+                log::info!("loading [{}]: {}", threads, filename);
+
+                let file = std::fs::File::open(entry.path())?;
+                let reader = std::io::BufReader::new(file);
+                let data = serde_json::from_reader(reader)?;
+
+                res.insert(threads, data);
+            }
+        }
+
+        Ok(Self::new(res))
+    }
+
+    pub fn threads(&self) -> Vec<u32> {
+        self.data.keys().copied().collect()
+    }
+
+    pub fn series_names(&self) -> BTreeSet<String> {
+        self.data
+            .iter()
+            .flat_map(|(_, results)| results.iter())
+            .map(|result| result.name.clone())
+            .collect()
+    }
+
+    pub fn select_series(
+        &self,
+        name: &str,
+    ) -> Option<Vec<(u32, BenchResult)>> {
+        let res = self
+            .data
+            .iter()
+            .filter_map(|(&threads, results)| {
+                results.iter().find_map(|result| {
+                    if result.name == name {
+                        Some((threads, result.clone()))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect::<Vec<(u32, BenchResult)>>();
+
+        if res.is_empty() { None } else { Some(res) }
+    }
+}

--- a/dev-crates/report-tool/src/util/mod.rs
+++ b/dev-crates/report-tool/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod bench_data;


### PR DESCRIPTION
- Added `ParBenchData` abstraction for managing parallel benchmark data efficiently.
- Refactored `dev_cmd` to utilize `ParBenchData` for thread and series management.
- Enabled `plotters` in `report-tool` with `svg_backend` and additional custom features.
- Updated dependencies and modified Cargo configuration to accommodate new features.