### PR TITLE
Refactor TGraph generation with modular enhancements

### DIFF
--- a/dev-crates/report-tool/src/commands/dev_cmd.rs
+++ b/dev-crates/report-tool/src/commands/dev_cmd.rs
@@ -49,19 +49,84 @@ impl DevArgs {
         let output_dir = Path::new(&self.output_dir);
         std::fs::create_dir_all(output_dir)?;
 
-        build_plot(
+        build_external_tgraph(
             &self.model,
-            &output_dir.join(format!("tgraph.{}.svg", self.model)),
+            &output_dir.join(format!("tgraph.external.{}.svg", self.model)),
             &data,
         )?;
+        for accel in [false, true] {
+            build_internal_tgraph(
+                &self.model,
+                accel,
+                &output_dir.join(format!(
+                    "tgraph.{}.{}.svg",
+                    if accel { "logos" } else { "regex" },
+                    self.model
+                )),
+                &data,
+            )?;
+        }
 
         Ok(())
     }
 }
 
-#[allow(unused)]
-fn build_plot<P: AsRef<Path>>(
+struct Point {
+    pub threads: u32,
+    pub bps: f64,
+}
+
+enum SeriesKind {
+    Internal,
+    External,
+}
+
+struct Series {
+    pub name: String,
+    pub style: ShapeStyle,
+    pub kind: SeriesKind,
+    pub points: Vec<Point>,
+}
+impl Series {
+    pub fn min_threads(&self) -> u32 {
+        self.points.iter().map(|p| p.threads).min().unwrap()
+    }
+
+    pub fn max_threads(&self) -> u32 {
+        self.points.iter().map(|p| p.threads).max().unwrap()
+    }
+
+    pub fn min_bps(&self) -> f64 {
+        self.points
+            .iter()
+            .map(|p| p.bps)
+            .min_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap()
+    }
+
+    pub fn max_bps(&self) -> f64 {
+        self.points
+            .iter()
+            .map(|p| p.bps)
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap()
+    }
+}
+
+fn external_styles() -> BTreeMap<String, ShapeStyle> {
+    [
+        ("bpe_openai".to_string(), palette::GREEN_400.filled()),
+        ("tiktoken".to_string(), palette::RED_200.filled()),
+        ("tokenizers".to_string(), palette::BLUE_300.filled()),
+    ]
+    .iter()
+    .cloned()
+    .collect()
+}
+
+fn build_internal_tgraph<P: AsRef<Path>>(
     model: &str,
+    accel: bool,
     plot_path: &P,
     data: &ParBenchData,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -69,47 +134,124 @@ fn build_plot<P: AsRef<Path>>(
 
     log::info!("Plotting to {}", plot_path.display());
 
-    struct Point {
-        pub threads: u32,
-        pub bps: f64,
-    }
+    let span_map: BTreeMap<&str, ShapeStyle> = [
+        ("bpe_backtrack", palette::GREY_A400.filled()),
+        ("buffer_sweep", palette::GREEN_A400.filled()),
+        ("merge_heap", palette::BLUE_A400.filled()),
+        ("priority_merge", palette::PINK_A700.filled()),
+        ("tail_sweep", palette::DEEPPURPLE_A400.filled()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
 
-    enum SeriesKind {
-        Internal,
-        External,
-    }
+    let mut plot_series: Vec<Series> = Default::default();
 
-    struct Series {
-        pub name: String,
-        pub style: ShapeStyle,
-        pub kind: SeriesKind,
-        pub points: Vec<Point>,
-    }
-    impl Series {
-        pub fn min_threads(&self) -> u32 {
-            self.points.iter().map(|p| p.threads).min().unwrap()
-        }
+    for (span, style) in span_map.iter() {
+        let sname = format!(
+            "encoding_parallel::wordchipper::{span}::{model}{}",
+            if accel { "_fast" } else { "" },
+        );
 
-        pub fn max_threads(&self) -> u32 {
-            self.points.iter().map(|p| p.threads).max().unwrap()
-        }
+        if let Some(series_data) = data.select_series(&sname) {
+            let style = if accel { style.filled() } else { *style };
 
-        pub fn min_bps(&self) -> f64 {
-            self.points
-                .iter()
-                .map(|p| p.bps)
-                .min_by(|a, b| a.partial_cmp(b).unwrap())
-                .unwrap()
-        }
-
-        pub fn max_bps(&self) -> f64 {
-            self.points
-                .iter()
-                .map(|p| p.bps)
-                .max_by(|a, b| a.partial_cmp(b).unwrap())
-                .unwrap()
+            plot_series.push(Series {
+                name: span.to_string(),
+                style,
+                kind: SeriesKind::Internal,
+                points: series_data
+                    .iter()
+                    .map(|(threads, bench_result)| Point {
+                        threads: *threads,
+                        bps: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
+                    })
+                    .collect(),
+            })
         }
     }
+
+    let min_threads = plot_series.iter().map(|s| s.min_threads()).min().unwrap();
+    let max_threads = plot_series.iter().map(|s| s.max_threads()).max().unwrap();
+    let min_bps = plot_series
+        .iter()
+        .map(|s| s.min_bps())
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let max_bps = plot_series
+        .iter()
+        .map(|s| s.max_bps())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+
+    let root = SVGBackend::new(plot_path, (640, 480)).into_drawing_area();
+    root.fill(&palette::WHITE)?;
+    let mut chart = ChartBuilder::on(&root)
+        .caption(
+            format!(
+                "encoder vrs, {} lexer, model: \"{}\"",
+                if accel { "logos" } else { "regex" },
+                model
+            ),
+            ("sans-serif", 20).into_font(),
+        )
+        .margin(10)
+        .x_label_area_size(40)
+        .y_label_area_size(90)
+        .build_cartesian_2d(
+            (min_threads..max_threads).log_scale().base(2.0),
+            min_bps..max_bps,
+        )?;
+
+    chart
+        .configure_mesh()
+        .x_desc("Thread Count")
+        .y_desc("Throughput")
+        .y_label_formatter(&|&bps| {
+            format!("{}/s", humansize::format_size_i(bps, humansize::BINARY))
+        })
+        .draw()?;
+
+    for pseries in plot_series {
+        let name = &pseries.name;
+        let style = pseries.style;
+        let points: Vec<(u32, f64)> = pseries.points.iter().map(|p| (p.threads, p.bps)).collect();
+
+        let size = 4;
+        chart
+            .draw_series(
+                points
+                    .iter()
+                    .map(|coord| EmptyElement::at(*coord) + Circle::new((0, 0), size, style)),
+            )?
+            .label(name)
+            .legend(move |coord| EmptyElement::at(coord) + Circle::new((0, 0), size, style));
+
+        chart.draw_series(LineSeries::new(
+            pseries.points.iter().map(|p| (p.threads, p.bps)),
+            style,
+        ))?;
+    }
+
+    chart
+        .configure_series_labels()
+        .position(SeriesLabelPosition::LowerRight)
+        .background_style(WHITE.mix(0.8))
+        .border_style(BLACK)
+        .draw()?;
+
+    root.present()?;
+
+    Ok(())
+}
+fn build_external_tgraph<P: AsRef<Path>>(
+    model: &str,
+    plot_path: &P,
+    data: &ParBenchData,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let plot_path = plot_path.as_ref();
+
+    log::info!("Plotting to {}", plot_path.display());
 
     let mut plot_series: Vec<Series> = Default::default();
 
@@ -119,16 +261,7 @@ fn build_plot<P: AsRef<Path>>(
         .filter(|name| name.contains(model))
         .collect::<Vec<_>>();
 
-    let ext_map: BTreeMap<&str, ShapeStyle> = [
-        ("bpe_openai", palette::GREEN_400.filled()),
-        ("tiktoken", palette::RED_200.filled()),
-        ("tokenizers", palette::BLUE_300.filled()),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    for (ext, style) in ext_map.iter() {
+    for (ext, style) in external_styles().iter() {
         if let Some(name) = series_names.iter().find(|name| name.contains(ext)) {
             let series_data = data.select_series(name).unwrap();
 
@@ -197,12 +330,12 @@ fn build_plot<P: AsRef<Path>>(
     root.fill(&palette::WHITE)?;
     let mut chart = ChartBuilder::on(&root)
         .caption(
-            format!("model: \"{}\"", model),
+            format!("library vrs, model: \"{}\"", model),
             ("sans-serif", 20).into_font(),
         )
         .margin(10)
         .x_label_area_size(40)
-        .y_label_area_size(70)
+        .y_label_area_size(90)
         .build_cartesian_2d(
             (min_threads..max_threads).log_scale().base(2.0),
             (min_bps..max_bps).log_scale().base(2.0),


### PR DESCRIPTION
Refactored the TGraph generation process to improve modularity and expand functionality. Key updates include:

- Replaced `build_plot` with `build_internal_tgraph` and `build_external_tgraph`, providing clearer separation of concerns.
- Added support for both accelerated ("logos") and non-accelerated ("regex") internal TGraphs.
- Introduced an `external_styles` helper for cleaner external series styling.
- Enhanced layout configuration options, including updates to `y_label_area_size` for Cartesian plots.