### PR TITLE
Refactor `dev_cmd` for clarity and add relative throughput graphs

### DIFF
--- a/dev-crates/report-tool/src/commands/dev_cmd.rs
+++ b/dev-crates/report-tool/src/commands/dev_cmd.rs
@@ -4,6 +4,7 @@ use std::{
     path::Path,
 };
 
+use divan_parser::BenchResult;
 use plotters::{
     prelude::{
         IntoLogRange,
@@ -66,6 +67,18 @@ impl DevArgs {
                 &data,
             )?;
         }
+        for accel in [false, true] {
+            build_internal_rel_tgraph(
+                &self.model,
+                accel,
+                &output_dir.join(format!(
+                    "tgraph.rel.{}.{}.svg",
+                    if accel { "logos" } else { "regex" },
+                    self.model
+                )),
+                &data,
+            )?;
+        }
 
         Ok(())
     }
@@ -73,7 +86,7 @@ impl DevArgs {
 
 struct Point {
     pub threads: u32,
-    pub bps: f64,
+    pub value: f64,
 }
 
 enum SeriesKind {
@@ -99,7 +112,7 @@ impl Series {
     pub fn min_bps(&self) -> f64 {
         self.points
             .iter()
-            .map(|p| p.bps)
+            .map(|p| p.value)
             .min_by(|a, b| a.partial_cmp(b).unwrap())
             .unwrap()
     }
@@ -107,7 +120,7 @@ impl Series {
     pub fn max_bps(&self) -> f64 {
         self.points
             .iter()
-            .map(|p| p.bps)
+            .map(|p| p.value)
             .max_by(|a, b| a.partial_cmp(b).unwrap())
             .unwrap()
     }
@@ -124,6 +137,155 @@ fn external_styles() -> BTreeMap<String, ShapeStyle> {
     .collect()
 }
 
+fn fmax(
+    a: f64,
+    b: f64,
+) -> f64 {
+    match a.partial_cmp(&b).unwrap() {
+        std::cmp::Ordering::Less => b,
+        std::cmp::Ordering::Equal => a,
+        std::cmp::Ordering::Greater => a,
+    }
+}
+
+fn bps(br: &BenchResult) -> f64 {
+    br.throughput_bps.as_ref().unwrap().mean.unwrap()
+}
+
+fn build_internal_rel_tgraph<P: AsRef<Path>>(
+    model: &str,
+    accel: bool,
+    plot_path: &P,
+    data: &ParBenchData,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let plot_path = plot_path.as_ref();
+
+    log::info!("Plotting to {}", plot_path.display());
+
+    let span_map: BTreeMap<&str, ShapeStyle> = [
+        ("bpe_backtrack", palette::GREY_A400.filled()),
+        ("buffer_sweep", palette::GREEN_A400.filled()),
+        ("merge_heap", palette::BLUE_A400.filled()),
+        ("priority_merge", palette::PINK_A700.filled()),
+        ("tail_sweep", palette::DEEPPURPLE_A400.filled()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let span_key = |span: &str| {
+        format!(
+            "encoding_parallel::wordchipper::{span}::{model}{}",
+            if accel { "_fast" } else { "" },
+        )
+    };
+
+    let mut baseline: BTreeMap<u32, f64> = Default::default();
+    for span in span_map.keys() {
+        if let Some(series_data) = data.select_series(&span_key(span)) {
+            for (threads, bench_result) in series_data.iter() {
+                let bps = bps(bench_result);
+
+                let entry = baseline.entry(*threads).or_default();
+                *entry = fmax(*entry, bps);
+            }
+        }
+    }
+
+    let mut plot_series: Vec<Series> = Default::default();
+    for (span, style) in span_map.iter() {
+        if let Some(series_data) = data.select_series(&span_key(span)) {
+            let style = if accel { style.filled() } else { *style };
+
+            plot_series.push(Series {
+                name: span.to_string(),
+                style,
+                kind: SeriesKind::Internal,
+                points: series_data
+                    .iter()
+                    .map(|(threads, bench_result)| Point {
+                        threads: *threads,
+                        value: bps(bench_result) / baseline[threads],
+                    })
+                    .collect(),
+            })
+        }
+    }
+
+    let min_threads = plot_series.iter().map(|s| s.min_threads()).min().unwrap();
+    let max_threads = plot_series.iter().map(|s| s.max_threads()).max().unwrap();
+    let min_bps = plot_series
+        .iter()
+        .map(|s| s.min_bps())
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let max_bps = plot_series
+        .iter()
+        .map(|s| s.max_bps())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+
+    let root = SVGBackend::new(plot_path, (640, 480)).into_drawing_area();
+    root.fill(&palette::WHITE)?;
+    let mut chart = ChartBuilder::on(&root)
+        .caption(
+            format!(
+                "encoder vrs max, {} lexer, model: \"{}\"",
+                if accel { "logos" } else { "regex" },
+                model
+            ),
+            ("sans-serif", 20).into_font(),
+        )
+        .margin(10)
+        .x_label_area_size(40)
+        .y_label_area_size(90)
+        .build_cartesian_2d(
+            (min_threads..max_threads).log_scale().base(2.0),
+            min_bps..max_bps,
+        )?;
+
+    chart
+        .configure_mesh()
+        .x_desc("Thread Count")
+        .y_desc("Relative Throughput")
+        .draw()?;
+
+    for pseries in plot_series {
+        let name = &pseries.name;
+        let style = pseries.style;
+        let points: Vec<(u32, f64)> = pseries
+            .points
+            .iter()
+            .map(|p| (p.threads, p.value))
+            .collect();
+
+        let size = 4;
+        chart
+            .draw_series(
+                points
+                    .iter()
+                    .map(|coord| EmptyElement::at(*coord) + Circle::new((0, 0), size, style)),
+            )?
+            .label(name)
+            .legend(move |coord| EmptyElement::at(coord) + Circle::new((0, 0), size, style));
+
+        chart.draw_series(LineSeries::new(
+            pseries.points.iter().map(|p| (p.threads, p.value)),
+            style,
+        ))?;
+    }
+
+    chart
+        .configure_series_labels()
+        .position(SeriesLabelPosition::LowerRight)
+        .background_style(WHITE.mix(0.8))
+        .border_style(BLACK)
+        .draw()?;
+
+    root.present()?;
+
+    Ok(())
+}
 fn build_internal_tgraph<P: AsRef<Path>>(
     model: &str,
     accel: bool,
@@ -164,7 +326,7 @@ fn build_internal_tgraph<P: AsRef<Path>>(
                     .iter()
                     .map(|(threads, bench_result)| Point {
                         threads: *threads,
-                        bps: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
+                        value: bps(bench_result),
                     })
                     .collect(),
             })
@@ -215,7 +377,11 @@ fn build_internal_tgraph<P: AsRef<Path>>(
     for pseries in plot_series {
         let name = &pseries.name;
         let style = pseries.style;
-        let points: Vec<(u32, f64)> = pseries.points.iter().map(|p| (p.threads, p.bps)).collect();
+        let points: Vec<(u32, f64)> = pseries
+            .points
+            .iter()
+            .map(|p| (p.threads, p.value))
+            .collect();
 
         let size = 4;
         chart
@@ -228,7 +394,7 @@ fn build_internal_tgraph<P: AsRef<Path>>(
             .legend(move |coord| EmptyElement::at(coord) + Circle::new((0, 0), size, style));
 
         chart.draw_series(LineSeries::new(
-            pseries.points.iter().map(|p| (p.threads, p.bps)),
+            pseries.points.iter().map(|p| (p.threads, p.value)),
             style,
         ))?;
     }
@@ -273,7 +439,7 @@ fn build_external_tgraph<P: AsRef<Path>>(
                     .iter()
                     .map(|(threads, bench_result)| Point {
                         threads: *threads,
-                        bps: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
+                        value: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
                     })
                     .collect(),
             })
@@ -305,7 +471,7 @@ fn build_external_tgraph<P: AsRef<Path>>(
                         .iter()
                         .map(|(threads, bench_result)| Point {
                             threads: *threads,
-                            bps: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
+                            value: bench_result.throughput_bps.as_ref().unwrap().mean.unwrap(),
                         })
                         .collect(),
                 })
@@ -353,7 +519,11 @@ fn build_external_tgraph<P: AsRef<Path>>(
     for pseries in plot_series {
         let name = &pseries.name;
         let style = pseries.style;
-        let points: Vec<(u32, f64)> = pseries.points.iter().map(|p| (p.threads, p.bps)).collect();
+        let points: Vec<(u32, f64)> = pseries
+            .points
+            .iter()
+            .map(|p| (p.threads, p.value))
+            .collect();
 
         match pseries.kind {
             SeriesKind::Internal => {
@@ -389,7 +559,7 @@ fn build_external_tgraph<P: AsRef<Path>>(
         }
 
         chart.draw_series(LineSeries::new(
-            pseries.points.iter().map(|p| (p.threads, p.bps)),
+            pseries.points.iter().map(|p| (p.threads, p.value)),
             style,
         ))?;
     }


### PR DESCRIPTION
- Refactored `dev_cmd` to introduce `build_internal_rel_tgraph` for creating relative throughput graphs for internal series.
- Renamed `bps` to `value` across relevant sections for improved clarity and consistency.
- Modularized and optimized logic for series processing and plotting.