### PR TITLE
Add tests for TokenizerImpl and TokenizerOptions, refactor common_decoder_tests

### DIFF
--- a/crates/wordchipper/src/decoders/slab_index_decoder.rs
+++ b/crates/wordchipper/src/decoders/slab_index_decoder.rs
@@ -148,7 +148,7 @@ mod tests {
     use super::*;
     use crate::{
         alloc::sync::Arc,
-        decoders::utility::testing::common_decoder_unit_test,
+        decoders::utility::testing::common_decoder_tests,
         pretrained::openai::OA_CL100K_BASE_PATTERN,
         spanners::TextSpanningConfig,
         vocab::{
@@ -175,6 +175,6 @@ mod tests {
 
         assert_eq!(decoder.expected_bytes_per_token(), 7.5);
 
-        common_decoder_unit_test(vocab, &decoder);
+        common_decoder_tests(vocab, Arc::new(decoder));
     }
 }

--- a/crates/wordchipper/src/decoders/token_dict_decoder.rs
+++ b/crates/wordchipper/src/decoders/token_dict_decoder.rs
@@ -124,7 +124,7 @@ mod tests {
     use super::*;
     use crate::{
         alloc::sync::Arc,
-        decoders::utility::testing::common_decoder_unit_test,
+        decoders::utility::testing::common_decoder_tests,
         pretrained::openai::OA_CL100K_BASE_PATTERN,
         spanners::TextSpanningConfig,
         vocab::{
@@ -153,6 +153,6 @@ mod tests {
 
         assert_eq!(decoder.token_spans(), &decoder.token_spans);
 
-        common_decoder_unit_test(vocab, &decoder);
+        common_decoder_tests(vocab, Arc::new(decoder));
     }
 }

--- a/crates/wordchipper/src/decoders/utility/pair_decoder.rs
+++ b/crates/wordchipper/src/decoders/utility/pair_decoder.rs
@@ -121,7 +121,7 @@ mod tests {
     use super::*;
     use crate::{
         alloc::sync::Arc,
-        decoders::utility::testing::common_decoder_unit_test,
+        decoders::utility::testing::common_decoder_tests,
         pretrained::openai::OA_CL100K_BASE_PATTERN,
         spanners::TextSpanningConfig,
         vocab::{
@@ -149,6 +149,7 @@ mod tests {
         assert_eq!(decoder.token_pairs(), &decoder.token_pairs);
         assert_eq!(&decoder.byte_vocab, vocab.byte_vocab());
 
-        common_decoder_unit_test(vocab, &decoder);
+        let decoder: Arc<dyn TokenDecoder<T>> = Arc::new(decoder);
+        common_decoder_tests(vocab, decoder);
     }
 }

--- a/crates/wordchipper/src/decoders/utility/testing.rs
+++ b/crates/wordchipper/src/decoders/utility/testing.rs
@@ -9,10 +9,7 @@ use crate::{
         vec::Vec,
     },
     decoders::TokenDecoder,
-    support::{
-        strings::string_from_utf8_lossy,
-        traits::static_is_send_sync_check,
-    },
+    support::strings::string_from_utf8_lossy,
     vocab::{
         UnifiedTokenVocab,
         VocabIndex,
@@ -20,12 +17,10 @@ use crate::{
 };
 
 /// Common Unittest for TokenDecoder implementations.
-pub fn common_decoder_unit_test<T: TokenType, D: TokenDecoder<T>>(
+pub fn common_decoder_tests<T: TokenType>(
     vocab: Arc<UnifiedTokenVocab<T>>,
-    decoder: &D,
+    decoder: Arc<dyn TokenDecoder<T>>,
 ) {
-    static_is_send_sync_check(decoder);
-
     let samples = vec![
         "hello world",
         "hello san francisco",

--- a/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
+++ b/crates/wordchipper/src/support/concurrency/rayon/rayon_decoder.rs
@@ -85,7 +85,7 @@ mod tests {
     use crate::{
         TokenDecoderOptions,
         UnifiedTokenVocab,
-        decoders::utility::testing::common_decoder_unit_test,
+        decoders::utility::testing::common_decoder_tests,
         pretrained::openai::OA_CL100K_BASE_PATTERN,
         spanners::TextSpanningConfig,
         vocab::utility::testing::{
@@ -109,6 +109,6 @@ mod tests {
             .build(vocab.clone());
         let decoder = ParallelRayonDecoder::new(inner);
 
-        common_decoder_unit_test(vocab, &decoder);
+        common_decoder_tests(vocab, Arc::new(decoder));
     }
 }

--- a/crates/wordchipper/src/tokenizer/tokenizer_impl.rs
+++ b/crates/wordchipper/src/tokenizer/tokenizer_impl.rs
@@ -117,3 +117,36 @@ impl<T: TokenType> TokenDecoder<T> for Tokenizer<T> {
         self.decoder.try_decode_batch_to_strings(batch)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        TokenizerOptions,
+        decoders::utility::testing::common_decoder_tests,
+        encoders::testing::common_encoder_tests,
+        pretrained::openai::OA_CL100K_BASE_PATTERN,
+        spanners::TextSpanningConfig,
+        vocab::utility::testing::{
+            build_test_shift_byte_vocab,
+            build_test_vocab,
+        },
+    };
+
+    #[test]
+    fn test_tokenizer_impl() {
+        type T = u32;
+
+        let vocab: Arc<UnifiedTokenVocab<T>> = build_test_vocab(
+            build_test_shift_byte_vocab(10),
+            TextSpanningConfig::from_pattern(OA_CL100K_BASE_PATTERN),
+        )
+        .into();
+
+        let tokenizer = TokenizerOptions::default().build(vocab.clone());
+
+        common_encoder_tests(vocab.clone(), tokenizer.clone());
+
+        common_decoder_tests(vocab.clone(), tokenizer.clone());
+    }
+}

--- a/crates/wordchipper/src/tokenizer/tokenizer_options.rs
+++ b/crates/wordchipper/src/tokenizer/tokenizer_options.rs
@@ -138,3 +138,42 @@ impl TokenizerOptions {
         .into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_coherent() {
+        let options = TokenizerOptions::default()
+            .with_parallel(false)
+            .with_concurrent(false);
+        assert_eq!(options.is_concurrent(), false);
+
+        let options = TokenizerOptions::default()
+            .with_parallel(true)
+            .with_concurrent(false);
+        assert_eq!(options.is_concurrent(), true);
+
+        let options = TokenizerOptions::default()
+            .with_parallel(false)
+            .with_concurrent(true);
+        assert_eq!(options.is_concurrent(), true);
+    }
+
+    #[test]
+    fn test_tokenizer_options_defaults() {
+        let options = TokenizerOptions::default();
+        assert_eq!(options.encoder, TokenEncoderOptions::default());
+        assert_eq!(options.decoder, TokenDecoderOptions::default());
+        assert_eq!(options.accelerated_lexers(), true);
+        assert_eq!(options.parallel(), false);
+
+        let options = options.with_parallel(true).with_accelerated_lexers(false);
+        assert_eq!(options.accelerated_lexers(), false);
+        assert_eq!(options.parallel(), true);
+
+        assert_eq!(options.encoder.parallel(), true);
+        assert_eq!(options.decoder.parallel(), true);
+    }
+}


### PR DESCRIPTION
- Add test_tokenizer_impl using common encoder/decoder tests
- Add test_is_coherent and test_tokenizer_options_defaults for TokenizerOptions
- Rename common_decoder_unit_test to common_decoder_tests
- Update common_decoder_tests to accept Arc<dyn TokenDecoder<T>> instead of generic reference
- Update all decoder test callsites to use Arc wrapper
