### PR TITLE
Add regex-automata tier to encoding_single bench

### DIFF
--- a/dev-crates/wordchipper-bench/benches/encoding_single.rs
+++ b/dev-crates/wordchipper-bench/benches/encoding_single.rs
@@ -77,9 +77,9 @@ pub fn bench_wc(
     }
 
     let spanner = builder.build();
-    let encoder: Arc<dyn TokenEncoder<u32>> = Arc::new(
-        TokenSpanEncoder::<u32>::new_with_selector(spanner, vocab, selector),
-    );
+    let encoder: Arc<dyn TokenEncoder<u32>> = Arc::new(TokenSpanEncoder::<u32>::new_with_selector(
+        spanner, vocab, selector,
+    ));
 
     bencher
         .counter(BytesCount::new(text.len()))
@@ -717,7 +717,6 @@ mod english {
             }
         }
     }
-
 }
 
 mod diverse {
@@ -1320,6 +1319,4 @@ mod diverse {
             }
         }
     }
-
 }
-


### PR DESCRIPTION
## Summary
- Refactor `bench_wc` to use `LexerMode` enum and `TextSpannerBuilder` directly (matching `encoding_parallel`'s approach)
- Add `regex_automata` modules for all 6 corpus/model combinations (30 new benchmarks)
- Previous bench only tested logos and fancy-regex; the regex-automata middle tier was missing because `TokenEncoderOptions` doesn't expose a `regex_automata` flag

## Test plan
- [ ] `cargo check -p wordchipper-bench --bench encoding_single` compiles
- [ ] `cargo bench -p wordchipper-bench --bench encoding_single -- "regex_automata"` runs and produces results