### PR TITLE
Add code coverage reporting to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,19 @@ jobs:
       - run: cargo test -p wordchipper --no-default-features --features client,fast-hash
       - run: cargo test -p wordchipper --no-default-features --tests
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+
   cross:
     name: Cross (no_std)
     runs-on: ubuntu-latest
@@ -97,7 +110,7 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [ fmt, clippy, test, cross, wasm, python, lexer-equivalence ]
+    needs: [ fmt, clippy, test, coverage, cross, wasm, python, lexer-equivalence ]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -105,6 +118,7 @@ jobs:
             "${{ needs.fmt.result }}"
             "${{ needs.clippy.result }}"
             "${{ needs.test.result }}"
+            "${{ needs.coverage.result }}"
             "${{ needs.cross.result }}"
             "${{ needs.wasm.result }}"
             "${{ needs.python.result }}"


### PR DESCRIPTION
## Summary

- Add a `coverage` CI job using `cargo-llvm-cov` to collect LCOV coverage data
- Upload results to Codecov via `codecov/codecov-action@v5`
- Add the coverage job to the CI gate

## Setup required

After merging, install the [Codecov GitHub App](https://github.com/apps/codecov) on the repo. Optionally add a `CODECOV_TOKEN` repository secret for authenticated uploads.

Closes #279

## Test plan

- [ ] Verify the coverage job runs successfully in CI
- [ ] Confirm Codecov receives the upload (check codecov.io dashboard)
- [ ] Open a follow-up PR to verify coverage diff comments appear