### PR TITLE
Fix Python publish CI: rustls-tls and macOS runner

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,8 +38,8 @@ jobs:
           # Linux aarch64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          # macOS x86_64
-          - os: macos-13
+          # macOS x86_64 (cross-compile from ARM)
+          - os: macos-14
             target: x86_64-apple-darwin
           # macOS Apple Silicon
           - os: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,8 +1227,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1238,9 +1240,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1393,6 +1397,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1857,6 +1878,12 @@ checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
 dependencies = [
  "logos-codegen",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -2393,6 +2420,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2729,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2654,6 +2737,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2661,6 +2746,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2668,6 +2754,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2714,6 +2801,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-std-workspace-alloc"
@@ -2764,6 +2857,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3288,7 +3382,7 @@ dependencies = [
  "fancy-regex",
  "lazy_static",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -3381,6 +3475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ doc_markdown = "deny"
 compact_str = "0.9.0"
 dary_heap = "0.3.5"
 directories-next = "2.0.0"
-downloader = "0.2.7"
+downloader = { version = "0.2.7", default-features = false }
 hashbrown = "0.16.0"
 inventory = "0.3.20"
 jsonl = "4.0.1"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,4 +19,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["extension-module"] }
-wordchipper = { path = "../../crates/wordchipper", features = ["client"] }
+wordchipper = { path = "../../crates/wordchipper", features = ["datagym", "rustls-tls"] }

--- a/crates/wordchipper-disk-cache/Cargo.toml
+++ b/crates/wordchipper-disk-cache/Cargo.toml
@@ -14,11 +14,21 @@ rust-version.workspace = true
 workspace = true
 
 
+[features]
+default = ["default-tls"]
+
+## Use the platform-native TLS backend (OpenSSL on Linux, SChannel on Windows, Security.framework on macOS).
+default-tls = ["downloader/default-tls"]
+
+## Use rustls (pure Rust) TLS backend. Useful for cross-compilation and manylinux builds.
+rustls-tls = ["downloader/rustls-tls"]
+
+
 [dependencies]
 directories-next = { workspace = true }
 
 # features=["tui"} incompatible with conflicting indicatif versions.
-downloader = { workspace = true }
+downloader = { workspace = true, default-features = false }
 
 
 [dev-dependencies]

--- a/crates/wordchipper/Cargo.toml
+++ b/crates/wordchipper/Cargo.toml
@@ -28,15 +28,30 @@ default = [
 ]
 
 ## The base set of features needed to load and run pre-trained encoders and decoders.
+## Uses platform-native TLS by default (OpenSSL on Linux). Combine with `rustls-tls`
+## instead of `default-tls` for environments without system OpenSSL (e.g. manylinux).
 client = [
     "download",
     "datagym",
+    "default-tls",
 ]
 
 ## The download feature enables downloading vocabularies from the internet.
 download = [
     "dep:wordchipper-disk-cache",
     "std",
+]
+
+## Use the platform-native TLS backend (OpenSSL on Linux).
+default-tls = [
+    "download",
+    "wordchipper-disk-cache/default-tls",
+]
+
+## Use rustls (pure Rust) TLS backend for downloads. Useful for manylinux builds.
+rustls-tls = [
+    "download",
+    "wordchipper-disk-cache/rustls-tls",
 ]
 
 ## The "std" feature enables the use of the `std` library.
@@ -118,7 +133,7 @@ foldhash = { workspace = true, optional = true }
 unicode-general-category = { workspace = true }
 
 # "download" feature deps:
-wordchipper-disk-cache = { version = "0.9.0", path = "../wordchipper-disk-cache", optional = true }
+wordchipper-disk-cache = { version = "0.9.0", path = "../wordchipper-disk-cache", optional = true, default-features = false }
 
 # "parallel" feature deps:
 rayon = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

- **Linux builds (x86_64 + aarch64)**: `openssl-sys` fails to build inside manylinux Docker containers because they lack OpenSSL development headers. Added a `rustls-tls` feature chain (`wordchipper` -> `wordchipper-disk-cache` -> `downloader`) so the Python binding uses pure-Rust TLS and avoids OpenSSL entirely.
- **macOS x86_64**: `macos-13` runner is deprecated. Switched to `macos-14` which cross-compiles to `x86_64-apple-darwin`.
- The `client` feature still defaults to `default-tls` (OpenSSL) for backwards compatibility with existing Rust consumers.

## Test plan

- [ ] Python Publish workflow passes on all platforms (Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, Windows)
- [ ] `cargo check -p wordchipper --features client` still works (backwards compat)
- [ ] `cargo check -p wordchipper-python` compiles without openssl-sys