### PR TITLE
Use manylinux_2_28 for aarch64 Python wheels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,9 +35,10 @@ jobs:
           # Linux x86_64
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          # Linux aarch64
+          # Linux aarch64 (manylinux_2_28 needed for ring cross-compilation)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            manylinux: manylinux_2_28
           # macOS x86_64 (cross-compile from ARM)
           - os: macos-14
             target: x86_64-apple-darwin
@@ -64,7 +65,7 @@ jobs:
           args: --release --out dist --find-interpreter
           working-directory: bindings/python
           sccache: true
-          manylinux: auto
+          manylinux: ${{ matrix.manylinux || 'auto' }}
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.target }}


### PR DESCRIPTION
## Summary

- The `manylinux2014` container (CentOS 7, GCC 4.8) fails to cross-compile `ring` for aarch64 because its GCC doesn't define `__ARM_ARCH` when assembling ARM `.S` files
- Switch the aarch64 Linux target to `manylinux_2_28` (AlmaLinux 8, GCC 8+) which handles aarch64 cross-compilation correctly
- Uses a matrix variable with `${{ matrix.manylinux || 'auto' }}` so only aarch64 is affected

## Test plan

- [ ] Python Publish workflow `aarch64-unknown-linux-gnu` job passes