### PR TITLE
Add PyPI project description and readme metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 *by [ZSpaceLabs](https://zspacelabs.ai)*
 
+[![PyPI](https://img.shields.io/pypi/v/wordchipper)](https://pypi.org/project/wordchipper/)
 [![Crates.io Version](https://img.shields.io/crates/v/wordchipper)](https://crates.io/crates/wordchipper)
 [![Documentation](https://img.shields.io/docsrs/wordchipper)](https://docs.rs/wordchipper/latest/wordchipper/)
 [![Test Status](https://github.com/zspacelabs/wordchipper/actions/workflows/ci.yml/badge.svg)](https://github.com/zspacelabs/wordchipper/actions/workflows/ci.yml)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,7 +1,26 @@
 # wordchipper
 
+[![PyPI](https://img.shields.io/pypi/v/wordchipper)](https://pypi.org/project/wordchipper/)
+[![Crates.io Version](https://img.shields.io/crates/v/wordchipper)](https://crates.io/crates/wordchipper)
+[![Documentation](https://img.shields.io/docsrs/wordchipper)](https://docs.rs/wordchipper/latest/wordchipper/)
+[![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)](#license)
+[![Discord](https://img.shields.io/discord/1475229838754316502?label=discord)](https://discord.gg/vBgXHWCeah)
+
 Python bindings for the [wordchipper](https://github.com/zspacelabs/wordchipper) BPE tokenizer
-library.
+library, by [ZSpaceLabs](https://zspacelabs.ai).
+
+`wordchipper` is a high-performance Rust byte-pair encoder tokenizer for the OpenAI GPT-2 tokenizer
+family. Under Python wrappers, we see a range of ~2x-4x (4 to 64 cores) speedups over
+[tiktoken](https://github.com/openai/tiktoken).
+
+| x 64 Core   | r50k python | o200k python |
+| ----------- | ----------- | ------------ |
+| wordchipper | 110.5 MiB/s | 106.5 MiB/s  |
+| tiktoken    | 25.5 MiB/s  | 32.7 MiB/s   |
+| tokenizers  | 20.8 MiB/s  | 23.2 MiB/s   |
+
+Read the full performance paper:
+[wordchipper: Fast BPE Tokenization with Substitutable Internals](https://zspacelabs.ai/wordchipper/articles/substitutable/)
 
 ## Installation
 
@@ -45,8 +64,8 @@ tok.save_base64_vocab("vocab.tiktoken")
 
 ## Compatibility wrappers
 
-Drop-in replacements for `tiktoken` and HuggingFace `tokenizers`. Change one import
-line and the rest of your code stays the same:
+Drop-in replacements for `tiktoken` and HuggingFace `tokenizers`. Change one import line and the
+rest of your code stays the same:
 
 ```python
 # tiktoken compat
@@ -62,9 +81,9 @@ output = tok.encode("hello world")
 output.ids      # [24912, 2375]
 ```
 
-Parameters that are accepted for API compatibility but not implemented (e.g.
-`allowed_special`, `disallowed_special`, `is_pretokenized`) will raise
-`NotImplementedError` when set to non-default values.
+Parameters that are accepted for API compatibility but not implemented (e.g. `allowed_special`,
+`disallowed_special`, `is_pretokenized`) will raise `NotImplementedError` when set to non-default
+values.
 
 ## Development
 
@@ -87,9 +106,9 @@ After making changes to `src/lib.rs`, rebuild with `maturin develop` before re-r
 
 ## Benchmarks
 
-Compares `wordchipper` against `tiktoken` and HuggingFace `tokenizers` for single
-and batch encoding on cl100k_base and o200k_base. Uses the same corpora and methodology
-as the Rust benchmarks in `wordchipper-bench`:
+Compares `wordchipper` against `tiktoken` and HuggingFace `tokenizers` for single and batch encoding
+on cl100k_base and o200k_base. Uses the same corpora and methodology as the Rust benchmarks in
+`wordchipper-bench`:
 
 - **Single-string**: `english.txt` / `multilingual.txt` repeated 10x
 - **Batch**: 1024 samples from fineweb-edu shard 0 (~4.2 MB)
@@ -116,3 +135,9 @@ pytest benchmarks/ -k "TestSingleDecode"
 # Filter by model
 pytest benchmarks/ -k "cl100k_base"
 ```
+
+## License
+
+`wordchipper` is distributed under the terms of both the MIT license and the Apache License (Version
+2.0). See [LICENSE-APACHE](https://github.com/zspacelabs/wordchipper/blob/main/LICENSE-APACHE) and
+[LICENSE-MIT](https://github.com/zspacelabs/wordchipper/blob/main/LICENSE-MIT) for details.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,6 +4,9 @@ build-backend = "maturin"
 
 [project]
 name = "wordchipper"
+description = "Fast BPE tokenizer library with tiktoken and HuggingFace compatibility"
+readme = "README.md"
+license = "MIT OR Apache-2.0"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
## Summary

- Add `description`, `readme`, and `license` fields to `pyproject.toml`
- Fixes the "No project description provided" shown on PyPI

## Test plan

- [ ] Next PyPI publish renders the README on the package page