### PR TITLE
Add nightly Miri CI for undefined behavior detection

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Lexer Equivalence
+name: Nightly
 
 on:
   schedule:
@@ -9,6 +9,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install nightly --component miri
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo +nightly miri test -p wordchipper
+      - name: File bug on failure
+        if: failure()
+        run: |
+          TITLE="Nightly Miri failure: undefined behavior detected"
+          BODY="The nightly Miri test found undefined behavior. See [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
+          existing=$(gh issue list --state open --search "${TITLE} in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label bug
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lexer-equivalence-k6:
     name: Lexer Equivalence (k=6)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ You need stable Rust (MSRV 1.93.0) and nightly `rustfmt`:
 
 ```sh
 rustup toolchain install stable nightly
-rustup component add --toolchain nightly rustfmt
+rustup component add --toolchain nightly rustfmt miri
 ```
 
 For WASM work: `cargo install wasm-pack`  
@@ -47,6 +47,9 @@ cargo clippy --no-deps
 cargo test --workspace
 cargo test -p wordchipper --no-default-features --features client,fast-hash
 cargo test -p wordchipper --no-default-features --tests
+
+# Miri (undefined behavior detection, requires nightly)
+cargo +nightly miri test -p wordchipper
 
 # no_std cross-check
 cargo check -p wordchipper --target wasm32-unknown-unknown --no-default-features


### PR DESCRIPTION
## Summary
- Add Miri job to the nightly workflow that runs `cargo +nightly miri test -p wordchipper`
- Auto-files a bug issue on failure (same pattern as the existing lexer equivalence job)
- Update CONTRIBUTING.md with Miri setup and local usage instructions

Closes #354