### PR TITLE
Fix Miri CI: disable isolation for proptest

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,8 @@ jobs:
       - run: rustup toolchain install nightly --component miri
       - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly miri test -p wordchipper
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"
       - name: File bug on failure
         if: failure()
         run: |


### PR DESCRIPTION
## Summary
- Adds `MIRIFLAGS="-Zmiri-disable-isolation"` to the nightly Miri CI step
- Fixes false positive from proptest calling `getcwd()` for failure persistence, which Miri blocks under default isolation mode
- This is not actual undefined behavior; Miri still checks for UB with isolation disabled

Closes #366