### PR TITLE
Add machete CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --no-deps
 
+  machete:
+    name: Unused Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-machete
+      - run: cargo machete
+
   test:
     name: Build and Test
     runs-on: ubuntu-latest
@@ -119,13 +129,14 @@ jobs:
   ci:
     name: CI
     if: always()
-    needs: [ fmt, clippy, test, coverage, cross, wasm, python, lexer-equivalence ]
+    needs: [ fmt, clippy, machete, test, coverage, cross, wasm, python, lexer-equivalence ]
     runs-on: ubuntu-latest
     steps:
       - run: |
           results=(
             "${{ needs.fmt.result }}"
             "${{ needs.clippy.result }}"
+            "${{ needs.machete.result }}"
             "${{ needs.test.result }}"
             "${{ needs.coverage.result }}"
             "${{ needs.cross.result }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,15 +18,17 @@ rustup component add --toolchain nightly rustfmt miri
 For WASM work: `cargo install wasm-pack`  
 For Python bindings: `uv` + `maturin` (`uv pip install maturin pytest`)  
 For the book: `cargo install mdbook`
+For unused dependency checks: `cargo install cargo-machete`
 
 ---
 
 ## Workflow
 
 1. Format: `cargo +nightly fmt`
-2. Lint: `cargo clippy --no-deps` (fix all warnings — they're treated as errors in CI)
-3. Test: `cargo test --workspace`
-4. Commit.
+2. Check unused dependencies: `cargo machete`
+3. Lint: `cargo clippy --no-deps` (fix all warnings — they're treated as errors in CI)
+4. Test: `cargo test --workspace`
+5. Commit.
 
 A convenience script `fix.sh` runs format and clippy together if it exists at the repo root.
 
@@ -42,6 +44,9 @@ cargo +nightly fmt --check
 
 # Lint
 cargo clippy --no-deps
+
+# Unused dependencies
+cargo machete
 
 # Tests (default features, alternate feature set, no_std surface)
 cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,7 +2711,6 @@ dependencies = [
  "plotters",
  "plotters-backend",
  "regex",
- "serde",
  "serde_json",
  "wordchipper-cli-util",
 ]
@@ -4352,7 +4351,6 @@ dependencies = [
  "divan-parser",
  "log",
  "rayon",
- "serde",
  "serde_json",
  "tiktoken-rs",
  "tokenizers",

--- a/dev-crates/report-tool/Cargo.toml
+++ b/dev-crates/report-tool/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 wordchipper-cli-util = { path = "../../crates/wordchipper-cli-util" }
 divan-parser = { path = "../divan-parser" }
 
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 humansize = { workspace = true }
 # fontlib issues, investigate wasm install.

--- a/dev-crates/wordchipper-bench/Cargo.toml
+++ b/dev-crates/wordchipper-bench/Cargo.toml
@@ -20,7 +20,6 @@ bpe-openai = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 divan = { workspace = true }
 rayon = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tiktoken-rs = { workspace = true }
 tokenizers = { workspace = true, features = ["http"] }


### PR DESCRIPTION
Machete is a Cargo utility tool that flags unused dependencies in `Cargo.toml`. This PR removes the unused `serde` dependency from `report-tool` and `wordchipper-bench`. Since both are dev-dependencies, this change does not affect semver.

This PR also adds Machete to CI to provide a guardrail against unnecessary dependency inclusion in the future.
