### PR TITLE
0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,6 @@ jobs:
             "${{ needs.clippy.result }}"
             "${{ needs.machete.result }}"
             "${{ needs.test.result }}"
-            "${{ needs.coverage.result }}"
             "${{ needs.cross.result }}"
             "${{ needs.wasm.result }}"
             "${{ needs.python.result }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "clap",
  "clap-markdown",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-cli-util"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow",
  "clap",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-disk-cache"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "directories-next",
  "downloader",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-python"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "pyo3",
  "wordchipper",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-training"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "compact_str",
  "dary_heap",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "wordchipper-wasm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.22.1",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,7 +2480,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4317,6 +4326,7 @@ dependencies = [
  "fancy-regex",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
+ "indoc",
  "inventory",
  "log",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 repository = "https://github.com/zspacelabs/wordchipper"
 rust-version = "1.93.0"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ divan = { package = "codspeed-divan-compat", version = "4.3.0" }
 document-features = "0.2.12"
 humansize = "2.1.3"
 indicatif = "0.18.4"
+indoc = "2.0.7"
 js-sys = "0.3"
 parquet = "58.0.0"
 proptest = "1.10.0"

--- a/crates/wordchipper-cli-util/Cargo.toml
+++ b/crates/wordchipper-cli-util/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-wordchipper = { version = "0.9.1", path = "../wordchipper", features = ["client"] }
+wordchipper = { version = "0.9.2", path = "../wordchipper", features = ["client"] }
 stderrlog = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/wordchipper-cli/Cargo.toml
+++ b/crates/wordchipper-cli/Cargo.toml
@@ -12,9 +12,9 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-wordchipper = { version = "0.9.1", path = "../wordchipper", features = ["client"] }
-wordchipper-training = { version = "0.9.1", path = "../wordchipper-training" }
-wordchipper-cli-util = { version = "0.9.1", path = "../wordchipper-cli-util" }
+wordchipper = { version = "0.9.2", path = "../wordchipper", features = ["client"] }
+wordchipper-training = { version = "0.9.2", path = "../wordchipper-training" }
+wordchipper-cli-util = { version = "0.9.2", path = "../wordchipper-cli-util" }
 log = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap-markdown = { workspace = true }

--- a/crates/wordchipper-training/Cargo.toml
+++ b/crates/wordchipper-training/Cargo.toml
@@ -25,7 +25,7 @@ tracing = [
 
 [dependencies]
 log = { workspace = true }
-wordchipper = { version = "0.9.1", path = "../wordchipper", features = ["std"] }
+wordchipper = { version = "0.9.2", path = "../wordchipper", features = ["std"] }
 compact_str = { workspace = true }
 dary_heap = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/wordchipper/Cargo.toml
+++ b/crates/wordchipper/Cargo.toml
@@ -34,6 +34,7 @@ client = [
     "download",
     "datagym",
     "default-tls",
+    "huggingface",
 ]
 
 ## The download feature enables downloading vocabularies from the internet.
@@ -102,6 +103,12 @@ tracing = [
 testing = []
 
 
+## Enable loading pretrained huggingface modules.
+huggingface = [
+    "std",
+    "dep:tokenizers",
+]
+
 
 [dependencies]
 # macro packages.
@@ -140,6 +147,8 @@ rayon = { workspace = true, optional = true }
 
 # "tracing" feature deps:
 tracing = { workspace = true, optional = true }
+
+tokenizers = { workspace = true, features = ["http"], optional = true }
 
 
 [dev-dependencies]

--- a/crates/wordchipper/Cargo.toml
+++ b/crates/wordchipper/Cargo.toml
@@ -141,7 +141,7 @@ foldhash = { workspace = true, optional = true }
 unicode-general-category = { workspace = true }
 
 # "download" feature deps:
-wordchipper-disk-cache = { version = "0.9.1", path = "../wordchipper-disk-cache", optional = true, default-features = false }
+wordchipper-disk-cache = { version = "0.9.2", path = "../wordchipper-disk-cache", optional = true, default-features = false }
 
 # "parallel" feature deps:
 rayon = { workspace = true, optional = true }

--- a/crates/wordchipper/Cargo.toml
+++ b/crates/wordchipper/Cargo.toml
@@ -125,6 +125,7 @@ ringbuffer = { workspace = true }
 regex = { workspace = true, features = ["unicode"] }
 regex-automata = { workspace = true, features = ["alloc", "meta", "nfa-thompson", "hybrid", "unicode"] }
 strum = { workspace = true }
+indoc = { workspace = true }
 
 # Provides HashMap/HashSet in no_std mode (non-optional so `default-features = false` just works).
 hashbrown = { workspace = true, features = ["alloc"] }

--- a/crates/wordchipper/README.md
+++ b/crates/wordchipper/README.md
@@ -76,6 +76,11 @@ configuration.
 For a number of pretrained models, simplified constructors are
 available to download, cache, and load the vocabulary.
 
+At this time, we have support for the following loaders:
+
+* `openai:[{PATH}/]{NAME}` - Lod pre-trained OpenAI models.
+* `hf:[{PATH}/]{NAME}` - Load pre-trained HuggingFace models.
+
 See: [wordchipper::get_model](
 https://docs.rs/wordchipper/latest/wordchipper/fn.get_model.html)
 

--- a/crates/wordchipper/README.md
+++ b/crates/wordchipper/README.md
@@ -18,6 +18,12 @@ and ~6.9x-9.2x when using custom DFA lexers for specific OpenAI vocabularies.
 Under python wrappers, we see a range of ~2x-4x (4 to 64 cores) speedups over
 [tiktoken](https://github.com/openai/tiktoken).
 
+### Changelog
+
+* 0.9.1 - 2023-03-22
+    - Add support for remote huggingface loading (via `hf:[{PATH}/]{NAME}`)
+    - Detect / error on vocabs with orphan tokens: [Bug 386](https://github.com/zspacelabs/wordchipper/issues/386)
+
 ### Suite Crates
 
 This is the main crate for the [wordchipper](https://github.com/zspacelabs/wordchipper) project.

--- a/crates/wordchipper/src/errors.rs
+++ b/crates/wordchipper/src/errors.rs
@@ -5,12 +5,16 @@ use crate::alloc::string::String;
 /// Errors from wordchipper operations.
 #[derive(Debug, thiserror::Error)]
 pub enum WCError {
+    /// Not Implemented Error.
+    #[error("Not Implemented: {0}")]
+    NotImplemented(String),
+
     /// Resource not found.
-    #[error("{0}")]
+    #[error("Resource Not Found: {0}")]
     ResourceNotFound(String),
 
     /// The resource is a duplicate.
-    #[error("{0}")]
+    #[error("Duplicate: {0}")]
     DuplicatedResource(String),
 
     /// Vocab size exceeds the capacity of the target token type.
@@ -28,7 +32,7 @@ pub enum WCError {
     },
 
     /// Vocabulary data is inconsistent.
-    #[error("{0}")]
+    #[error("Vocab Conflict: {0}")]
     VocabConflict(String),
 
     /// Token value out of range for the target type.

--- a/crates/wordchipper/src/pretrained/factory/vocab_description.rs
+++ b/crates/wordchipper/src/pretrained/factory/vocab_description.rs
@@ -21,20 +21,24 @@ pub struct VocabDescription {
 
 impl VocabDescription {
     /// Build a new vocabulary description.
-    pub fn new<Q>(
+    pub fn new<Q, C, D>(
         id: Q,
-        context: &[&str],
-        description: &str,
+        context: &[C],
+        description: D,
     ) -> Self
     where
         Q: Into<VocabQuery>,
+        C: AsRef<str>,
+        D: AsRef<str>,
     {
         let id = id.into();
+        let context = context.iter().map(|c| c.as_ref().to_string()).collect();
+        let description = description.as_ref().to_string();
 
         Self {
             id,
-            context: context.iter().map(|&s| s.to_string()).collect(),
-            description: description.to_string(),
+            context,
+            description,
         }
     }
 

--- a/crates/wordchipper/src/pretrained/factory/vocab_query.rs
+++ b/crates/wordchipper/src/pretrained/factory/vocab_query.rs
@@ -66,7 +66,7 @@ impl Display for VocabQuery {
 }
 
 impl VocabQuery {
-    /// Build a new query from structure.
+    /// Build a new query.
     pub fn new(
         schema: Option<&str>,
         path: Option<&str>,
@@ -174,6 +174,19 @@ impl VocabQuery {
         }
         query.name() == self.name()
     }
+
+    /// Build a cache context for this query.
+    pub fn to_context(&self) -> Vec<String> {
+        let mut context = Vec::new();
+        if let Some(schema) = self.schema() {
+            context.push(schema.to_string());
+        }
+        if let Some(path) = self.path() {
+            context.extend(path.split('/').map(|p| p.to_string()));
+        }
+        context.push(self.name().to_string());
+        context
+    }
 }
 
 #[cfg(test)]
@@ -202,6 +215,19 @@ mod tests {
             VocabQuery::new(Some("xyz"), Some("foo/bar"), "vocab_name")
         );
     }
+
+    #[test]
+    fn test_to_context() {
+        let q = VocabQuery::from_str("vocab_name").unwrap();
+        assert_eq!(q.to_context(), vec!["vocab_name"]);
+
+        let q = VocabQuery::from_str("foo/bar/vocab_name").unwrap();
+        assert_eq!(q.to_context(), vec!["foo", "bar", "vocab_name"]);
+
+        let q = VocabQuery::from_str("xyz:foo/bar/vocab_name").unwrap();
+        assert_eq!(q.to_context(), vec!["xyz", "foo", "bar", "vocab_name"]);
+    }
+
     #[test]
     fn test_vocab_query_with_schema() {
         let query = VocabQuery::new(None, None, "vocab_name").with_schema(Some("provider"));

--- a/crates/wordchipper/src/pretrained/factory/vocab_query.rs
+++ b/crates/wordchipper/src/pretrained/factory/vocab_query.rs
@@ -194,6 +194,7 @@ mod tests {
     use core::str::FromStr;
 
     use crate::{
+        alloc::vec,
         prelude::*,
         pretrained::factory::vocab_query::VocabQuery,
     };

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -1,3 +1,5 @@
+use std::println;
+
 use tokenizers::{
     ModelWrapper::BPE,
     PreTokenizerWrapper,
@@ -130,7 +132,21 @@ pub fn vocab_from_hf_tokenizer(tok: &Tokenizer) -> WCResult<Arc<UnifiedTokenVoca
 
     let hf_vocab = bpe.get_vocab();
 
-    let special_tokens: WCHashSet<u32> = tok.get_added_tokens_decoder().keys().copied().collect();
+    println!(
+        "Debug: {:?}",
+        hf_vocab.iter().find(|(_, id)| **id == 157513)
+    );
+
+    // TODO: This is broken for Qwen/Qwen3.5-9B for some reason.
+    let mut special_tokens: WCHashSet<T> = Default::default();
+
+    let decoder = tok.get_added_tokens_decoder();
+    println!("Debug: {:#?}", decoder);
+
+    for (t, at) in decoder.iter() {
+        span_config.specials_mut().add_str_word(&at.content, *t);
+        special_tokens.insert(*t);
+    }
 
     // Forward and inverse bytes_to_unicode maps.
     let b2c = bytes_char();
@@ -140,7 +156,7 @@ pub fn vocab_from_hf_tokenizer(tok: &Tokenizer) -> WCResult<Arc<UnifiedTokenVoca
     let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
     for (s, id) in &hf_vocab {
         if special_tokens.contains(id) {
-            span_config.specials_mut().add_str_word(s, *id);
+            continue;
         } else {
             let mut bytes = Vec::with_capacity(s.len());
             for ch in s.chars() {
@@ -157,7 +173,13 @@ pub fn vocab_from_hf_tokenizer(tok: &Tokenizer) -> WCResult<Arc<UnifiedTokenVoca
         }
     }
 
-    assert_eq!(span_config.specials().len(), special_tokens.len());
+    if span_config.specials().len() != special_tokens.len() {
+        return Err(WCError::External(format!(
+            "hf vocab identifies {} special tokens, but only {} special tokens found in span_config",
+            special_tokens.len(),
+            span_config.specials().len()
+        )));
+    }
 
     // Byte map: the single-char string for each byte must resolve in the vocab.
     let byte_tokens: Vec<T> = (0u8..=255)

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -37,118 +37,6 @@ use crate::{
     },
 };
 
-pub struct HFVocabProvider {}
-
-inventory::submit! {
-    VocabProviderInventoryHook::new(|| Arc::new(HFVocabProvider{}))
-}
-
-impl VocabProvider for HFVocabProvider {
-    fn name(&self) -> String {
-        "hf".to_string()
-    }
-
-    fn description(&self) -> String {
-        "HuggingFace vocabularies".to_string()
-    }
-
-    fn list_vocabs(&self) -> Vec<VocabDescription> {
-        vec![]
-    }
-
-    fn load_vocab(
-        &self,
-        query: &VocabQuery,
-        _loader: &mut dyn ResourceLoader,
-    ) -> WCResult<LabeledVocab<u32>> {
-        match query.schema() {
-            None => return Err(WCError::ResourceNotFound(query.to_string())),
-            Some(schema) => {
-                if schema != "hf" {
-                    return Err(WCError::ResourceNotFound(query.to_string()));
-                }
-            }
-        }
-
-        type T = u32;
-
-        let key = format!("{}/{}", query.path().unwrap(), query.name());
-        let id = format!("{}/{}", query.path().unwrap(), query.name());
-
-        match Tokenizer::from_pretrained(&key, None) {
-            Ok(tok) => {
-                let pattern = extract_pattern(tok.get_pre_tokenizer())?;
-                let span_config = TextSpanningConfig::from_pattern(RegexPattern::Adaptive(pattern));
-
-                let BPE(bpe) = tok.get_model() else {
-                    return Err(WCError::External(
-                        format!("{} is not BPE compatible", id).to_string(),
-                    ));
-                };
-
-                // TODO: Add support for unknown token.
-                if let Some(unk) = bpe.get_unk_token() {
-                    return Err(WCError::External(format!("BPE has unk_token {unk:?}")));
-                }
-
-                let vocab = bpe.get_vocab();
-
-                let specials: WCHashSet<u32> =
-                    tok.get_added_tokens_decoder().keys().copied().collect();
-
-                // Forward and inverse bytes_to_unicode maps.
-                let b2c = bytes_char();
-                let c2b: WCHashMap<char, u8> = b2c.iter().map(|(&b, &c)| (c, b)).collect();
-
-                // Span map: decode every non-special vocab string back to bytes.
-                let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
-                for (s, id) in &vocab {
-                    if specials.contains(id) {
-                        continue;
-                    }
-                    let mut bytes = Vec::with_capacity(s.len());
-                    for ch in s.chars() {
-                        match c2b.get(&ch) {
-                            Some(&b) => bytes.push(b),
-                            None => {
-                                return Err(WCError::External(format!(
-                                    "token {s:?} (id {id}) has non-byte-level codepoint {ch:?}"
-                                )));
-                            }
-                        }
-                    }
-                    span_map.insert(bytes, (*id));
-                }
-
-                // Byte map: the single-char string for each byte must resolve in the vocab.
-                let byte_tokens: Vec<T> = (0u8..=255)
-                    .map(|b| {
-                        let key: String = std::iter::once(b2c[&b]).collect();
-                        vocab.get(&key).copied().ok_or(b)
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|b| WCError::External(format!("missing byte token for 0x{b:02x}")))?;
-
-                let byte_map = ByteMapVocab::<T>::from_byte_to_token(&byte_tokens);
-                let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
-
-                let vocab: Arc<UnifiedTokenVocab<T>> =
-                    Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
-
-                let id = VocabQuery::new(Some("hf"), query.path(), query.name());
-
-                let descr: VocabDescription = VocabDescription::new(
-                    id,
-                    &["hf", query.path().unwrap(), query.name()],
-                    "Model loaded from hf",
-                );
-
-                Ok(LabeledVocab::new(descr, vocab))
-            }
-            Err(_) => Err(WCError::ResourceNotFound(query.to_string())),
-        }
-    }
-}
 // GPT-2 / r50k-style default, used when pretokenizer is a bare ByteLevel.
 const GPT2_PATTERN: &str =
     r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
@@ -184,8 +72,14 @@ fn extract_pattern(pt: Option<&PreTokenizerWrapper>) -> Result<String, WCError> 
     }
 }
 
-/// Converts bytes to unicode characters.
+/// Converts bytes to Unicode characters.
 /// See <https://github.com/openai/gpt-2/blob/master/src/encoder.py#L9>
+///
+/// This is from tokenizers; but is private in that crate.
+///
+/// TODO: Workout what this is doing, relative to the bytemap.
+/// This seems to be some default map for gpt2; and might be shared
+/// with the `BytMap` code for loading datagym.
 fn bytes_char() -> WCHashMap<u8, char> {
     let mut bs: Vec<u8> = vec![];
     bs.extend(b'!'..=b'~');
@@ -211,4 +105,114 @@ fn bytes_char() -> WCHashMap<u8, char> {
         .zip(cs)
         .map(|(f, t)| (f, unsafe { std::char::from_u32_unchecked(t) }))
         .collect()
+}
+
+pub struct HFVocabProvider {}
+
+inventory::submit! {
+    VocabProviderInventoryHook::new(|| Arc::new(HFVocabProvider{}))
+}
+
+impl VocabProvider for HFVocabProvider {
+    fn name(&self) -> String {
+        "hf".to_string()
+    }
+
+    fn description(&self) -> String {
+        "HuggingFace vocabularies".to_string()
+    }
+
+    fn list_vocabs(&self) -> Vec<VocabDescription> {
+        vec![]
+    }
+
+    fn load_vocab(
+        &self,
+        query: &VocabQuery,
+        _loader: &mut dyn ResourceLoader,
+    ) -> WCResult<LabeledVocab<u32>> {
+        if let Some(schema) = query.schema()
+            && schema != "hf"
+        {
+            return Err(WCError::ResourceNotFound(query.to_string()));
+        }
+
+        type T = u32;
+
+        match Tokenizer::from_pretrained(&query.clone().with_schema(None).to_string(), None) {
+            Ok(tok) => {
+                let pattern = extract_pattern(tok.get_pre_tokenizer())?;
+                let span_config = TextSpanningConfig::from_pattern(RegexPattern::Adaptive(pattern));
+
+                let BPE(bpe) = tok.get_model() else {
+                    return Err(WCError::External(
+                        format!("{} is not BPE compatible", query).to_string(),
+                    ));
+                };
+
+                // TODO: Add support for unknown token.
+                if let Some(unk) = bpe.get_unk_token() {
+                    return Err(WCError::External(format!("BPE has unk_token {unk:?}")));
+                }
+
+                let vocab = bpe.get_vocab();
+
+                let specials: WCHashSet<u32> =
+                    tok.get_added_tokens_decoder().keys().copied().collect();
+
+                // Forward and inverse bytes_to_unicode maps.
+                let b2c = bytes_char();
+                let c2b: WCHashMap<char, u8> = b2c.iter().map(|(&b, &c)| (c, b)).collect();
+
+                // Span map: decode every non-special vocab string back to bytes.
+                let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
+                for (s, id) in &vocab {
+                    if specials.contains(id) {
+                        continue;
+                    }
+                    let mut bytes = Vec::with_capacity(s.len());
+                    for ch in s.chars() {
+                        match c2b.get(&ch) {
+                            Some(&b) => bytes.push(b),
+                            None => {
+                                return Err(WCError::External(format!(
+                                    "token {s:?} (id {id}) has non-byte-level codepoint {ch:?}"
+                                )));
+                            }
+                        }
+                    }
+                    span_map.insert(bytes, *id);
+                }
+
+                // Byte map: the single-char string for each byte must resolve in the vocab.
+                let byte_tokens: Vec<T> = (0u8..=255)
+                    .map(|b| {
+                        let key: String = std::iter::once(b2c[&b]).collect();
+                        vocab.get(&key).copied().ok_or(b)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|b| WCError::External(format!("missing byte token for 0x{b:02x}")))?;
+
+                let byte_map = ByteMapVocab::<T>::from_byte_to_token(&byte_tokens);
+                let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
+
+                let vocab: Arc<UnifiedTokenVocab<T>> =
+                    Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
+
+                let id = query.clone().with_schema(Some("hf"));
+
+                let mut context = vec!["hf"];
+                if query.path().is_some() {
+                    context.push(query.path().unwrap());
+                }
+                context.push(query.name());
+
+                let descr: VocabDescription =
+                    VocabDescription::new(id, &context, "Model loaded from hf");
+
+                Ok(LabeledVocab::new(descr, vocab))
+            }
+            Err(_) => Err(WCError::ResourceNotFound(query.to_string())),
+        }
+    }
 }

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -1,0 +1,116 @@
+use tokenizers::{
+    ModelWrapper::BPE,
+    PreTokenizerWrapper::Split,
+    pre_tokenizers::split::SplitPattern,
+    tokenizer::Tokenizer,
+};
+
+use crate::{
+    LabeledVocab,
+    UnifiedTokenVocab,
+    VocabDescription,
+    VocabQuery,
+    WCError,
+    WCResult,
+    alloc::sync::Arc,
+    prelude::*,
+    pretrained::factory::{
+        VocabProvider,
+        VocabProviderInventoryHook,
+    },
+    spanners::TextSpanningConfig,
+    support::{
+        regex::RegexPattern,
+        resources::ResourceLoader,
+    },
+    vocab::{
+        ByteMapVocab,
+        SpanMapVocab,
+        SpanTokenMap,
+    },
+};
+
+pub struct HFVocabProvider {}
+
+inventory::submit! {
+    VocabProviderInventoryHook::new(|| Arc::new(HFVocabProvider{}))
+}
+
+impl VocabProvider for HFVocabProvider {
+    fn name(&self) -> String {
+        "hf".to_string()
+    }
+
+    fn description(&self) -> String {
+        "HuggingFace vocabularies".to_string()
+    }
+
+    fn list_vocabs(&self) -> Vec<VocabDescription> {
+        vec![]
+    }
+
+    fn load_vocab(
+        &self,
+        query: &VocabQuery,
+        _loader: &mut dyn ResourceLoader,
+    ) -> WCResult<LabeledVocab<u32>> {
+        type T = u32;
+
+        let key = format!("{}/{}", query.path().unwrap(), query.name());
+        match Tokenizer::from_pretrained(&key, None) {
+            Ok(tok) => {
+                let span_config = if let Some(Split(split)) = tok.get_pre_tokenizer() {
+                    let pattern = match &split.pattern {
+                        SplitPattern::Regex(str) => RegexPattern::Adaptive(str.to_string()),
+                        _ => return Err(WCError::External("No regex pattern".to_string())),
+                    };
+
+                    TextSpanningConfig::from_pattern(pattern)
+                } else {
+                    return Err(WCError::External("No pre-tokenizer".to_string()));
+                };
+
+                if let BPE(bpe) = tok.get_model() {
+                    let vocab = bpe.get_vocab();
+
+                    let span_map: SpanTokenMap<T> = vocab
+                        .iter()
+                        .map(|(s, t)| (s.as_bytes().to_vec(), *t))
+                        .collect();
+
+                    let byte_map: ByteMapVocab<T> = if let Some(byte_tokens) = (0..256)
+                        .map(|b| {
+                            let k = format!("<{b:#04X}>");
+                            vocab.get(&k).copied()
+                        })
+                        .collect::<Option<Vec<T>>>()
+                    {
+                        ByteMapVocab::<T>::from_byte_to_token(&byte_tokens)
+                    } else {
+                        return Err(WCError::External(
+                            "Unable to translate: no byte map".to_string(),
+                        ));
+                    };
+
+                    let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
+
+                    let vocab: Arc<UnifiedTokenVocab<T>> =
+                        Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
+
+                    let id = VocabQuery::new(Some("hf"), query.path(), query.name());
+
+                    let descr: VocabDescription = VocabDescription::new(
+                        id,
+                        &["hf", query.path().unwrap(), query.name()],
+                        "Model loaded from hf",
+                    );
+
+                    Ok(LabeledVocab::new(descr, vocab))
+                } else {
+                    Err(WCError::ResourceNotFound(query.to_string()))
+                }
+            }
+            Err(_) => Err(WCError::ResourceNotFound(query.to_string())),
+        }
+    }
+}

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -1,6 +1,11 @@
 use tokenizers::{
     ModelWrapper::BPE,
-    PreTokenizerWrapper::Split,
+    PreTokenizerWrapper,
+    PreTokenizerWrapper::{
+        ByteLevel,
+        Sequence,
+        Split,
+    },
     pre_tokenizers::split::SplitPattern,
     tokenizer::Tokenizer,
 };
@@ -11,6 +16,8 @@ use crate::{
     VocabDescription,
     VocabQuery,
     WCError,
+    WCHashMap,
+    WCHashSet,
     WCResult,
     alloc::sync::Arc,
     prelude::*,
@@ -54,63 +61,154 @@ impl VocabProvider for HFVocabProvider {
         query: &VocabQuery,
         _loader: &mut dyn ResourceLoader,
     ) -> WCResult<LabeledVocab<u32>> {
+        match query.schema() {
+            None => return Err(WCError::ResourceNotFound(query.to_string())),
+            Some(schema) => {
+                if schema != "hf" {
+                    return Err(WCError::ResourceNotFound(query.to_string()));
+                }
+            }
+        }
+
         type T = u32;
 
         let key = format!("{}/{}", query.path().unwrap(), query.name());
+        let id = format!("{}/{}", query.path().unwrap(), query.name());
+
         match Tokenizer::from_pretrained(&key, None) {
             Ok(tok) => {
-                let span_config = if let Some(Split(split)) = tok.get_pre_tokenizer() {
-                    let pattern = match &split.pattern {
-                        SplitPattern::Regex(str) => RegexPattern::Adaptive(str.to_string()),
-                        _ => return Err(WCError::External("No regex pattern".to_string())),
-                    };
+                let pattern = extract_pattern(tok.get_pre_tokenizer())?;
+                let span_config = TextSpanningConfig::from_pattern(RegexPattern::Adaptive(pattern));
 
-                    TextSpanningConfig::from_pattern(pattern)
-                } else {
-                    return Err(WCError::External("No pre-tokenizer".to_string()));
+                let BPE(bpe) = tok.get_model() else {
+                    return Err(WCError::External(
+                        format!("{} is not BPE compatible", id).to_string(),
+                    ));
                 };
 
-                if let BPE(bpe) = tok.get_model() {
-                    let vocab = bpe.get_vocab();
-
-                    let span_map: SpanTokenMap<T> = vocab
-                        .iter()
-                        .map(|(s, t)| (s.as_bytes().to_vec(), *t))
-                        .collect();
-
-                    let byte_map: ByteMapVocab<T> = if let Some(byte_tokens) = (0..256)
-                        .map(|b| {
-                            let k = format!("<{b:#04X}>");
-                            vocab.get(&k).copied()
-                        })
-                        .collect::<Option<Vec<T>>>()
-                    {
-                        ByteMapVocab::<T>::from_byte_to_token(&byte_tokens)
-                    } else {
-                        return Err(WCError::External(
-                            "Unable to translate: no byte map".to_string(),
-                        ));
-                    };
-
-                    let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
-
-                    let vocab: Arc<UnifiedTokenVocab<T>> =
-                        Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
-
-                    let id = VocabQuery::new(Some("hf"), query.path(), query.name());
-
-                    let descr: VocabDescription = VocabDescription::new(
-                        id,
-                        &["hf", query.path().unwrap(), query.name()],
-                        "Model loaded from hf",
-                    );
-
-                    Ok(LabeledVocab::new(descr, vocab))
-                } else {
-                    Err(WCError::ResourceNotFound(query.to_string()))
+                // TODO: Add support for unknown token.
+                if let Some(unk) = bpe.get_unk_token() {
+                    return Err(WCError::External(format!("BPE has unk_token {unk:?}")));
                 }
+
+                let vocab = bpe.get_vocab();
+
+                let specials: WCHashSet<u32> =
+                    tok.get_added_tokens_decoder().keys().copied().collect();
+
+                // Forward and inverse bytes_to_unicode maps.
+                let b2c = bytes_char();
+                let c2b: WCHashMap<char, u8> = b2c.iter().map(|(&b, &c)| (c, b)).collect();
+
+                // Span map: decode every non-special vocab string back to bytes.
+                let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
+                for (s, id) in &vocab {
+                    if specials.contains(id) {
+                        continue;
+                    }
+                    let mut bytes = Vec::with_capacity(s.len());
+                    for ch in s.chars() {
+                        match c2b.get(&ch) {
+                            Some(&b) => bytes.push(b),
+                            None => {
+                                return Err(WCError::External(format!(
+                                    "token {s:?} (id {id}) has non-byte-level codepoint {ch:?}"
+                                )));
+                            }
+                        }
+                    }
+                    span_map.insert(bytes, (*id));
+                }
+
+                // Byte map: the single-char string for each byte must resolve in the vocab.
+                let byte_tokens: Vec<T> = (0u8..=255)
+                    .map(|b| {
+                        let key: String = std::iter::once(b2c[&b]).collect();
+                        vocab.get(&key).copied().ok_or(b)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|b| WCError::External(format!("missing byte token for 0x{b:02x}")))?;
+
+                let byte_map = ByteMapVocab::<T>::from_byte_to_token(&byte_tokens);
+                let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
+
+                let vocab: Arc<UnifiedTokenVocab<T>> =
+                    Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
+
+                let id = VocabQuery::new(Some("hf"), query.path(), query.name());
+
+                let descr: VocabDescription = VocabDescription::new(
+                    id,
+                    &["hf", query.path().unwrap(), query.name()],
+                    "Model loaded from hf",
+                );
+
+                Ok(LabeledVocab::new(descr, vocab))
             }
             Err(_) => Err(WCError::ResourceNotFound(query.to_string())),
         }
     }
+}
+// GPT-2 / r50k-style default, used when pretokenizer is a bare ByteLevel.
+const GPT2_PATTERN: &str =
+    r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
+
+fn extract_pattern(pt: Option<&PreTokenizerWrapper>) -> Result<String, WCError> {
+    fn split_regex(s: &tokenizers::pre_tokenizers::split::Split) -> Result<String, WCError> {
+        match &s.pattern {
+            SplitPattern::Regex(r) => Ok(r.clone()),
+            _ => Err(WCError::External("Split without Regex pattern".into())),
+        }
+    }
+    match pt {
+        Some(Split(s)) => split_regex(s),
+        Some(ByteLevel(_)) => Ok(GPT2_PATTERN.to_string()),
+        Some(Sequence(seq)) => {
+            let mut found = None;
+            for sub in seq.as_ref() {
+                match &sub {
+                    Split(s) => {
+                        if found.is_some() {
+                            return Err(WCError::External("Sequence has multiple Splits".into()));
+                        }
+                        found = Some(split_regex(s)?);
+                    }
+                    ByteLevel(_) => {} // sibling byte-encoder, fine
+                    _ => return Err(WCError::External("unsupported member in Sequence".into())),
+                }
+            }
+            found.ok_or_else(|| WCError::External("Sequence has no Split regex".into()))
+        }
+        Some(_) => Err(WCError::External("unsupported pre-tokenizer".into())),
+        None => Err(WCError::External("no pre-tokenizer".into())),
+    }
+}
+
+/// Converts bytes to unicode characters.
+/// See <https://github.com/openai/gpt-2/blob/master/src/encoder.py#L9>
+fn bytes_char() -> WCHashMap<u8, char> {
+    let mut bs: Vec<u8> = vec![];
+    bs.extend(b'!'..=b'~');
+    bs.extend(b'\xA1'..=b'\xAC');
+    bs.extend(b'\xAE'..=b'\xFF');
+
+    let mut cs: Vec<u32> = bs.iter().map(|i| *i as u32).collect();
+    let mut n = 0;
+
+    for b in 0..=255u8 {
+        if !bs.contains(&b) {
+            bs.push(b);
+            cs.push(u32::pow(2, 8) + n);
+            n += 1;
+        }
+    }
+
+    // Safety: cs contains all values from bs (between 0 and 255),
+    // and some values of value 2⁸ + n, where n is between 0 and 255. This is
+    // between 255 and 512. Both ranges are valid UTF-32 values (which is fully
+    // saturated until 0xD000)
+    bs.into_iter()
+        .zip(cs)
+        .map(|(f, t)| (f, unsafe { std::char::from_u32_unchecked(t) }))
+        .collect()
 }

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -14,6 +14,7 @@ use crate::{
     LabeledVocab,
     UnifiedTokenVocab,
     VocabDescription,
+    VocabIndex,
     VocabQuery,
     WCError,
     WCHashMap,
@@ -21,9 +22,12 @@ use crate::{
     WCResult,
     alloc::sync::Arc,
     prelude::*,
-    pretrained::factory::{
-        VocabProvider,
-        VocabProviderInventoryHook,
+    pretrained::{
+        factory::{
+            VocabProvider,
+            VocabProviderInventoryHook,
+        },
+        openai::OA_GPT2_PATTERN,
     },
     spanners::TextSpanningConfig,
     support::{
@@ -37,20 +41,19 @@ use crate::{
     },
 };
 
-// GPT-2 / r50k-style default, used when pretokenizer is a bare ByteLevel.
-const GPT2_PATTERN: &str =
-    r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
-
-fn extract_pattern(pt: Option<&PreTokenizerWrapper>) -> Result<String, WCError> {
-    fn split_regex(s: &tokenizers::pre_tokenizers::split::Split) -> Result<String, WCError> {
+fn extract_pattern(pt: Option<&PreTokenizerWrapper>) -> Result<RegexPattern, WCError> {
+    fn split_regex(s: &tokenizers::pre_tokenizers::split::Split) -> Result<RegexPattern, WCError> {
         match &s.pattern {
-            SplitPattern::Regex(r) => Ok(r.clone()),
+            SplitPattern::Regex(r) => Ok(r.clone().into()),
             _ => Err(WCError::External("Split without Regex pattern".into())),
         }
     }
     match pt {
         Some(Split(s)) => split_regex(s),
-        Some(ByteLevel(_)) => Ok(GPT2_PATTERN.to_string()),
+        Some(ByteLevel(bl)) if bl.use_regex => Ok(OA_GPT2_PATTERN.into()),
+        Some(ByteLevel(_)) => Err(WCError::External(
+            "ByteLevel with use_regex=false has no splitting regex".into(),
+        )),
         Some(Sequence(seq)) => {
             let mut found = None;
             for sub in seq.as_ref() {
@@ -107,6 +110,84 @@ fn bytes_char() -> WCHashMap<u8, char> {
         .collect()
 }
 
+/// Attempt to convert a `HuggingFace` tokenizer to a `WordChipper` vocabulary.
+pub fn vocab_from_hf_tokenizer(tok: &Tokenizer) -> WCResult<Arc<UnifiedTokenVocab<u32>>> {
+    type T = u32;
+
+    let pattern = extract_pattern(tok.get_pre_tokenizer())?;
+    let mut span_config: TextSpanningConfig<T> = TextSpanningConfig::from_pattern(pattern);
+
+    let BPE(bpe) = tok.get_model() else {
+        return Err(WCError::External(
+            "Tokenizer is not BPE compatible".to_string(),
+        ));
+    };
+
+    // TODO: Add support for unknown token.
+    if let Some(unk) = bpe.get_unk_token() {
+        return Err(WCError::External(format!("BPE has unk_token {unk:?}")));
+    }
+
+    let hf_vocab = bpe.get_vocab();
+
+    let special_tokens: WCHashSet<u32> = tok.get_added_tokens_decoder().keys().copied().collect();
+
+    // Forward and inverse bytes_to_unicode maps.
+    let b2c = bytes_char();
+    let c2b: WCHashMap<char, u8> = b2c.iter().map(|(&b, &c)| (c, b)).collect();
+
+    // Span map: decode every non-special vocab string back to bytes.
+    let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
+    for (s, id) in &hf_vocab {
+        if special_tokens.contains(id) {
+            span_config.specials_mut().add_str_word(s, *id);
+        } else {
+            let mut bytes = Vec::with_capacity(s.len());
+            for ch in s.chars() {
+                match c2b.get(&ch) {
+                    Some(&b) => bytes.push(b),
+                    None => {
+                        return Err(WCError::External(format!(
+                            "token {s:?} (id {id}) has non-byte-level codepoint {ch:?}"
+                        )));
+                    }
+                }
+            }
+            span_map.insert(bytes, *id);
+        }
+    }
+
+    assert_eq!(span_config.specials().len(), special_tokens.len());
+
+    // Byte map: the single-char string for each byte must resolve in the vocab.
+    let byte_tokens: Vec<T> = (0u8..=255)
+        .map(|b| {
+            let key: String = std::iter::once(b2c[&b]).collect();
+            hf_vocab.get(&key).copied().ok_or(b)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|b| WCError::External(format!("missing byte token for 0x{b:02x}")))?;
+
+    let byte_map = ByteMapVocab::<T>::from_byte_to_token(&byte_tokens);
+    let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
+
+    let expected_len = span_vocab.len() + span_config.specials().len();
+
+    let vocab: Arc<UnifiedTokenVocab<T>> =
+        Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
+
+    // TODO: should `vocab.len()` include the special len()?
+    if vocab.len() + vocab.special_vocab().len() != expected_len {
+        return Err(WCError::External(format!(
+            "Expected {} tokens, got {}",
+            expected_len,
+            vocab.len()
+        )));
+    }
+
+    Ok(vocab)
+}
+
 pub struct HFVocabProvider {}
 
 inventory::submit! {
@@ -137,75 +218,18 @@ impl VocabProvider for HFVocabProvider {
             return Err(WCError::ResourceNotFound(query.to_string()));
         }
 
-        type T = u32;
-
-        match Tokenizer::from_pretrained(&query.clone().with_schema(None).to_string(), None) {
+        match Tokenizer::from_pretrained(query.clone().with_schema(None).to_string(), None) {
             Ok(tok) => {
-                let pattern = extract_pattern(tok.get_pre_tokenizer())?;
-                let span_config = TextSpanningConfig::from_pattern(RegexPattern::Adaptive(pattern));
-
-                let BPE(bpe) = tok.get_model() else {
-                    return Err(WCError::External(
-                        format!("{} is not BPE compatible", query).to_string(),
-                    ));
-                };
-
-                // TODO: Add support for unknown token.
-                if let Some(unk) = bpe.get_unk_token() {
-                    return Err(WCError::External(format!("BPE has unk_token {unk:?}")));
-                }
-
-                let vocab = bpe.get_vocab();
-
-                let specials: WCHashSet<u32> =
-                    tok.get_added_tokens_decoder().keys().copied().collect();
-
-                // Forward and inverse bytes_to_unicode maps.
-                let b2c = bytes_char();
-                let c2b: WCHashMap<char, u8> = b2c.iter().map(|(&b, &c)| (c, b)).collect();
-
-                // Span map: decode every non-special vocab string back to bytes.
-                let mut span_map: SpanTokenMap<T> = SpanTokenMap::default();
-                for (s, id) in &vocab {
-                    if specials.contains(id) {
-                        continue;
-                    }
-                    let mut bytes = Vec::with_capacity(s.len());
-                    for ch in s.chars() {
-                        match c2b.get(&ch) {
-                            Some(&b) => bytes.push(b),
-                            None => {
-                                return Err(WCError::External(format!(
-                                    "token {s:?} (id {id}) has non-byte-level codepoint {ch:?}"
-                                )));
-                            }
-                        }
-                    }
-                    span_map.insert(bytes, *id);
-                }
-
-                // Byte map: the single-char string for each byte must resolve in the vocab.
-                let byte_tokens: Vec<T> = (0u8..=255)
-                    .map(|b| {
-                        let key: String = std::iter::once(b2c[&b]).collect();
-                        vocab.get(&key).copied().ok_or(b)
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|b| WCError::External(format!("missing byte token for 0x{b:02x}")))?;
-
-                let byte_map = ByteMapVocab::<T>::from_byte_to_token(&byte_tokens);
-                let span_vocab = SpanMapVocab::<T>::new(byte_map, span_map)?;
-
-                let vocab: Arc<UnifiedTokenVocab<T>> =
-                    Arc::new(UnifiedTokenVocab::from_span_vocab(span_config, span_vocab)?);
-
-                let id = query.clone().with_schema(Some("hf"));
+                let vocab = vocab_from_hf_tokenizer(&tok)?;
 
                 let mut context = vec!["hf"];
                 if query.path().is_some() {
                     context.push(query.path().unwrap());
                 }
                 context.push(query.name());
+
+                let id = query.clone().with_schema(Some("hf"));
+                let context = id.to_context();
 
                 let descr: VocabDescription =
                     VocabDescription::new(id, &context, "Model loaded from hf");

--- a/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/hf_factory.rs
@@ -1,5 +1,3 @@
-use std::println;
-
 use tokenizers::{
     ModelWrapper::BPE,
     PreTokenizerWrapper,
@@ -132,16 +130,20 @@ pub fn vocab_from_hf_tokenizer(tok: &Tokenizer) -> WCResult<Arc<UnifiedTokenVoca
 
     let hf_vocab = bpe.get_vocab();
 
+    /*
     println!(
         "Debug: {:?}",
         hf_vocab.iter().find(|(_, id)| **id == 157513)
     );
+     */
 
     // TODO: This is broken for Qwen/Qwen3.5-9B for some reason.
     let mut special_tokens: WCHashSet<T> = Default::default();
 
     let decoder = tok.get_added_tokens_decoder();
+    /*
     println!("Debug: {:#?}", decoder);
+     */
 
     for (t, at) in decoder.iter() {
         span_config.specials_mut().add_str_word(&at.content, *t);

--- a/crates/wordchipper/src/pretrained/huggingface/mod.rs
+++ b/crates/wordchipper/src/pretrained/huggingface/mod.rs
@@ -1,0 +1,3 @@
+//! # `HuggingFace` Pretrained Models
+
+mod hf_factory;

--- a/crates/wordchipper/src/pretrained/mod.rs
+++ b/crates/wordchipper/src/pretrained/mod.rs
@@ -36,6 +36,9 @@
 pub mod factory;
 pub mod openai;
 
+#[cfg(feature = "huggingface")]
+pub mod huggingface;
+
 #[doc(inline)]
 pub use factory::{
     LabeledVocab,

--- a/crates/wordchipper/src/support/mod.rs
+++ b/crates/wordchipper/src/support/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "concurrent")]
 pub mod concurrency;
+
 pub mod ranges;
 pub mod regex;
 pub mod resources;
@@ -9,3 +10,4 @@ pub mod slices;
 pub mod strings;
 pub mod timers;
 pub mod traits;
+pub mod with_ok_or_panic;

--- a/crates/wordchipper/src/support/with_ok_or_panic.rs
+++ b/crates/wordchipper/src/support/with_ok_or_panic.rs
@@ -1,0 +1,61 @@
+//! # Result Utilities
+//!
+//! Methods for [`std::result::Result`] manipulation.
+
+use core::fmt::Display;
+
+/// Extension trait for `Result<T, E>` to add `ok_or_panic` method.
+pub trait WithOkOrPanic<T> {
+    /// Unwraps the `Result`, or panics with the error message.
+    ///
+    /// This differs from the behavior of [`Result::unwrap`]
+    /// in that the [`Debug`] format of the wrapped error is used
+    /// directly as the panic message; and not escaped.
+    fn ok_or_panic(self) -> T;
+}
+
+impl<T, E> WithOkOrPanic<T> for Result<T, E>
+where
+    E: Display,
+{
+    fn ok_or_panic(self) -> T {
+        match self {
+            Ok(t) => t,
+            Err(e) => panic!("{e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        WCError,
+        WCResult,
+        prelude::*,
+    };
+
+    fn try_example(
+        value: i32,
+        throw: bool,
+    ) -> WCResult<i32> {
+        if throw {
+            Err(WCError::External("throwing".to_string()))
+        } else {
+            Ok(value)
+        }
+    }
+
+    #[test]
+    fn test_expect_unwrap() {
+        let result = try_example(42, false);
+        assert_eq!(result.ok_or_panic(), 42);
+    }
+
+    #[should_panic(expected = "throwing")]
+    #[test]
+    fn test_expect_unwrap_panic() {
+        let result = try_example(42, true);
+        result.ok_or_panic();
+    }
+}

--- a/crates/wordchipper/src/vocab/pair_vocab.rs
+++ b/crates/wordchipper/src/vocab/pair_vocab.rs
@@ -47,19 +47,26 @@ pub fn try_validate_pair_map<T: TokenType>(
         }
     }
 
+    const ORPHAN_TOKENS_ERROR: &str = indoc::indoc! {r#"
+        This vocab has orphan tokens, which wordchipper does not yet support.
+        See: https://github.com/zspacelabs/wordchipper/issues/386
+    "#};
+
     for (&pair, &t) in pairs.iter() {
         for pt in [pair.0, pair.1] {
             let is_pair_target = pair_targets.contains(&pt);
             let byte_target = byte_vocab.get_byte(pt);
 
             if is_pair_target && let Some(b) = byte_target {
-                return Err(crate::WCError::VocabConflict(crate::alloc::format!(
-                    "Pair {pair:?} -> {t:?} parent {pt:?} is a pair target and byte target: {b:0x?}"
+                return Err(crate::WCError::NotImplemented(crate::alloc::format!(
+                    "{PRE}Pair {pair:?} -> {t:?} parent {pt:?} is a pair target and byte target: {b:0x?}",
+                    PRE = ORPHAN_TOKENS_ERROR,
                 )));
             }
             if !is_pair_target && byte_target.is_none() {
-                return Err(crate::WCError::VocabConflict(crate::alloc::format!(
-                    "Pair {pair:?} -> {t:?} parent {pt:?} is not defined"
+                return Err(crate::WCError::NotImplemented(crate::alloc::format!(
+                    "{PRE}Pair {pair:?} -> {t:?} parent {pt:?} is not defined",
+                    PRE = ORPHAN_TOKENS_ERROR,
                 )));
             }
         }

--- a/crates/wordchipper/src/vocab/span_vocab.rs
+++ b/crates/wordchipper/src/vocab/span_vocab.rs
@@ -3,6 +3,7 @@
 use crate::{
     WCResult,
     alloc::vec::Vec,
+    support::with_ok_or_panic::WithOkOrPanic,
     types::{
         TokenType,
         WCHashMap,
@@ -96,7 +97,7 @@ impl<T: TokenType> SpanMapVocab<T> {
     pub fn from_byte_vocab(byte_vocab: ByteMapVocab<T>) -> Self {
         let span_map: SpanTokenMap<T> = byte_vocab.span_pairs().collect();
 
-        Self::new(byte_vocab, span_map).unwrap()
+        Self::new(byte_vocab, span_map).ok_or_panic()
     }
 
     /// Build a [`Self`] from a [`SpanTokenMap`].
@@ -126,7 +127,7 @@ impl<T: TokenType> SpanMapVocab<T> {
 
         let byte_vocab: ByteMapVocab<T> = ByteMapVocab::from_byte_to_token(&byte_to_token);
 
-        Self::new(byte_vocab, span_map).unwrap()
+        Self::new(byte_vocab, span_map).ok_or_panic()
     }
 
     /// Initialize a [`SpanMapVocab`].
@@ -244,7 +245,7 @@ impl<T: TokenType> SpanMapVocab<T> {
             }
         }
 
-        PairMapVocab::<T>::new(byte_vocab, pairs).unwrap()
+        PairMapVocab::<T>::new(byte_vocab, pairs).ok_or_panic()
     }
 }
 


### PR DESCRIPTION
- **Add HuggingFace pretrained vocab provider and refactor bench data iteration**
- **Extend HF vocab provider to support byte-level BPE tokenizers**
- **Make hf factory a better pass-through factory.**
- **Add `VocabQuery::to_context()` method and refactor HF vocab provider**
- **Partial work on Qwen3.5.**
- **Update partial support for HF with basic errors.**
- **Fix no-std build.**
- **Setup 0.9.2**
